### PR TITLE
Added ability to get short time identifiers for TimeSpan

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -310,50 +310,59 @@ The default precision is set to .75 but you can pass your desired precision too.
 **No dehumanization for dates as `Humanize` is a lossy transformation and the human friendly date is not reversible**
 
 ###<a id="humanize-timespan">Humanize TimeSpan</a>
-You can call `Humanize` on a `TimeSpan` to a get human friendly representation for it:
+  You can call `Humanize` on a `TimeSpan` to a get human friendly representation for it:
 
-```C#
-TimeSpan.FromMilliseconds(1).Humanize() => "1 millisecond"
-TimeSpan.FromMilliseconds(2).Humanize() => "2 milliseconds"
-TimeSpan.FromDays(1).Humanize() => "1 day"
-TimeSpan.FromDays(16).Humanize() => "2 weeks"
-```
+  ```C#
+  TimeSpan.FromMilliseconds(1).Humanize() => "1 millisecond"
+  TimeSpan.FromMilliseconds(2).Humanize() => "2 milliseconds"
+  TimeSpan.FromDays(1).Humanize() => "1 day"
+  TimeSpan.FromDays(16).Humanize() => "2 weeks"
+  ```
 
-There is an optional `precision` parameter for `TimeSpan.Humanize` which allows you to specify the precision of the returned value.
-The default value of `precision` is 1 which means only the largest time unit is returned like you saw in `TimeSpan.FromDays(16).Humanize()`.
-Here is a few examples of specifying precision:
+  There is an optional `precision` parameter for `TimeSpan.Humanize` which allows you to specify the precision of the returned value.
+  The default value of `precision` is 1 which means only the largest time unit is returned like you saw in `TimeSpan.FromDays(16).Humanize()`.
+  Here is a few examples of specifying precision:
 
-```C#
-TimeSpan.FromDays(1).Humanize(precision:2) => "1 day" // no difference when there is only one unit in the provided TimeSpan
-TimeSpan.FromDays(16).Humanize(2) => "2 weeks, 2 days"
+  ```C#
+  TimeSpan.FromDays(1).Humanize(precision:2) => "1 day" // no difference when there is only one unit in the provided TimeSpan
+  TimeSpan.FromDays(16).Humanize(2) => "2 weeks, 2 days"
 
-// the same TimeSpan value with different precision returns different results
-TimeSpan.FromMilliseconds(1299630020).Humanize() => "2 weeks"
-TimeSpan.FromMilliseconds(1299630020).Humanize(3) => "2 weeks, 1 day, 1 hour"
-TimeSpan.FromMilliseconds(1299630020).Humanize(4) => "2 weeks, 1 day, 1 hour, 30 seconds"
-TimeSpan.FromMilliseconds(1299630020).Humanize(5) => "2 weeks, 1 day, 1 hour, 30 seconds, 20 milliseconds"
-```
+  // the same TimeSpan value with different precision returns different results
+  TimeSpan.FromMilliseconds(1299630020).Humanize() => "2 weeks"
+  TimeSpan.FromMilliseconds(1299630020).Humanize(3) => "2 weeks, 1 day, 1 hour"
+  TimeSpan.FromMilliseconds(1299630020).Humanize(4) => "2 weeks, 1 day, 1 hour, 30 seconds"
+  TimeSpan.FromMilliseconds(1299630020).Humanize(5) => "2 weeks, 1 day, 1 hour, 30 seconds, 20 milliseconds"
+  ```
 
-Many localizations are available for this method:
+  There is an optional `strategy` parameter for `TimeSpan.Humanize` which allows you to get short or long time units.
+  The default value of `strategy` is `Long` which provides the default behaviour above.
+  Here is a few examples of specifying strategy with 'strategy:TimeSpanFormatStrategy.Short`:
 
-```C#
-// in de-DE culture
-TimeSpan.FromDays(1).Humanize() => "Ein Tag"
-TimeSpan.FromDays(2).Humanize() => "2 Tage"
+  ```C#
+  TimeSpan.FromDays(1).Humanize(strategy:TimeSpanFormatStrategy.Short) => "1d" // no difference when there is only one unit in the provided TimeSpan
+  TimeSpan.FromMilliseconds(320).Humanize(strategy:TimeSpanFormatStrategy.Short) => "320ms"
+  ```
 
-// in sk-SK culture
-TimeSpan.FromMilliseconds(1).Humanize() => "1 milisekunda"
-TimeSpan.FromMilliseconds(2).Humanize() => "2 milisekundy"
-TimeSpan.FromMilliseconds(5).Humanize() => "5 milisekúnd"
-```
+  Many localizations are available for this method:
 
-Culture to use can be specified explicitly. If it is not, current thread's current UI culture is used. Example:
+  ```C#
+  // in de-DE culture
+  TimeSpan.FromDays(1).Humanize() => "Ein Tag"
+  TimeSpan.FromDays(2).Humanize() => "2 Tage"
 
-```C#
-TimeSpan.FromDays(1).Humanize(culture: "ru-RU") => "один день"
-```
+  // in sk-SK culture
+  TimeSpan.FromMilliseconds(1).Humanize() => "1 milisekunda"
+  TimeSpan.FromMilliseconds(2).Humanize() => "2 milisekundy"
+  TimeSpan.FromMilliseconds(5).Humanize() => "5 milisekúnd"
+  ```
 
-###<a id="humanize-collections">Humanize Collections</a>
+  Culture to use can be specified explicitly. If it is not, current thread's current UI culture is used. Example:
+
+  ```C#
+  TimeSpan.FromDays(1).Humanize(culture: "ru-RU") => "один день"
+  ```
+
+  ###<a id="humanize-collections">Humanize Collections</a>
 You can call `Humanize` on any `IEnumerable` to get a nicely formatted string representing the objects in the collection. By default `ToString()` will be called on each item to get its representation but a formatting function may be passed to `Humanize` instead. Additionally, a default separator is provided("and" in English), but a different separator may be passed into `Humanize`.
 
 For instance:

--- a/readme.md
+++ b/readme.md
@@ -339,7 +339,8 @@ The default precision is set to .75 but you can pass your desired precision too.
   Here is a few examples of specifying strategy with 'strategy:TimeSpanFormatStrategy.Short`:
 
   ```C#
-  TimeSpan.FromDays(1).Humanize(strategy:TimeSpanFormatStrategy.Short) => "1d" // no difference when there is only one unit in the provided TimeSpan
+  TimeSpan.FromDays(1).Humanize(strategy:TimeSpanFormatStrategy.Short) => "1d"
+  TimeSpan.FromDays(2).Humanize(strategy:TimeSpanFormatStrategy.Short) => "2d"
   TimeSpan.FromMilliseconds(320).Humanize(strategy:TimeSpanFormatStrategy.Short) => "320ms"
   ```
 

--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
@@ -265,7 +265,7 @@ public class DefaultFormatter
     public DefaultFormatter(string localeCode) { }
     public string DateHumanize(Humanizer.Localisation.TimeUnit timeUnit, Humanizer.Localisation.Tense timeUnitTense, int unit) { }
     public string DateHumanize_Now() { }
-    public string TimeSpanHumanize(Humanizer.Localisation.TimeUnit timeUnit, int unit) { }
+    public string TimeSpanHumanize(Humanizer.Localisation.TimeUnit timeUnit, int unit, Humanizer.Localisation.Formatters.TimeSpanFormatStrategy strategy) { }
     public string TimeSpanHumanize_Zero() { }
 }
 
@@ -273,8 +273,15 @@ public interface IFormatter
 {
     string DateHumanize(Humanizer.Localisation.TimeUnit timeUnit, Humanizer.Localisation.Tense timeUnitTense, int unit);
     string DateHumanize_Now();
-    string TimeSpanHumanize(Humanizer.Localisation.TimeUnit timeUnit, int unit);
+    string TimeSpanHumanize(Humanizer.Localisation.TimeUnit timeUnit, int unit, Humanizer.Localisation.Formatters.TimeSpanFormatStrategy strategy);
     string TimeSpanHumanize_Zero();
+}
+
+public enum TimeSpanFormatStrategy
+{
+    Long,
+    Short,
+    value__,
 }
 
 public interface INumberToWordsConverter
@@ -463,7 +470,7 @@ public class StringHumanizeExtensions
 
 public class TimeSpanHumanizeExtensions
 {
-    public string Humanize(System.TimeSpan timeSpan, int precision, System.Globalization.CultureInfo culture) { }
+    public string Humanize(System.TimeSpan timeSpan, int precision, System.Globalization.CultureInfo culture, Humanizer.Localisation.Formatters.TimeSpanFormatStrategy strategy) { }
 }
 
 public class To

--- a/src/Humanizer.Tests/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests/TimeSpanHumanizeTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using Humanizer.Localisation.Formatters;
 using Xunit;
 using Xunit.Extensions;
 
@@ -19,12 +20,31 @@ namespace Humanizer.Tests
         }
 
         [Theory]
+        [InlineData(14, "2wk")]
+        [InlineData(7, "1wk")]
+        public void ShortWeeks(int days, string expected)
+        {
+			var actual = TimeSpan.FromDays(days).Humanize(strategy: TimeSpanFormatStrategy.Short);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
         [InlineData(6, "6 days")]
         [InlineData(2, "2 days")]
         [InlineData(1, "1 day")]
         public void Days(int days, string expected)
         {
             var actual = TimeSpan.FromDays(days).Humanize();
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(6, "6d")]
+        [InlineData(2, "2d")]
+        [InlineData(1, "1d")]
+        public void ShortDays(int days, string expected)
+        {
+			var actual = TimeSpan.FromDays(days).Humanize(strategy: TimeSpanFormatStrategy.Short);
             Assert.Equal(expected, actual);
         }
 
@@ -38,11 +58,29 @@ namespace Humanizer.Tests
         }
 
         [Theory]
+        [InlineData(2, "2h")]
+        [InlineData(1, "1h")]
+        public void ShortHours(int hours, string expected)
+        {
+			var actual = TimeSpan.FromHours(hours).Humanize(strategy: TimeSpanFormatStrategy.Short);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
         [InlineData(2, "2 minutes")]
         [InlineData(1, "1 minute")]
         public void Minutes(int minutes, string expected)
         {
             var actual = TimeSpan.FromMinutes(minutes).Humanize();
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(2, "2m")]
+        [InlineData(1, "1m")]
+        public void ShortMinutes(int minutes, string expected)
+        {
+			var actual = TimeSpan.FromMinutes(minutes).Humanize(strategy: TimeSpanFormatStrategy.Short);
             Assert.Equal(expected, actual);
         }
 
@@ -58,6 +96,17 @@ namespace Humanizer.Tests
         }
 
         [Theory]
+        [InlineData(135, "2m")]
+        [InlineData(60, "1m")]
+        [InlineData(2, "2s")]
+        [InlineData(1, "1s")]
+        public void ShortSeconds(int seconds, string expected)
+        {
+            var actual = TimeSpan.FromSeconds(seconds).Humanize(strategy:TimeSpanFormatStrategy.Short);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
         [InlineData(2500, "2 seconds")]
         [InlineData(1400, "1 second")]
         [InlineData(2, "2 milliseconds")]
@@ -65,6 +114,17 @@ namespace Humanizer.Tests
         public void Milliseconds(int ms, string expected)
         {
             var actual = TimeSpan.FromMilliseconds(ms).Humanize();
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(2500, "2s")]
+        [InlineData(1400, "1s")]
+        [InlineData(2, "2ms")]
+        [InlineData(1, "1ms")]
+        public void ShortMilliseconds(int ms, string expected)
+        {
+            var actual = TimeSpan.FromMilliseconds(ms).Humanize(strategy:TimeSpanFormatStrategy.Short);
             Assert.Equal(expected, actual);
         }
 

--- a/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/DefaultFormatter.cs
@@ -46,22 +46,23 @@ namespace Humanizer.Localisation.Formatters
         /// <returns>Returns 0 seconds as the string representation of Zero TimeSpan</returns>
         public virtual string TimeSpanHumanize_Zero()
         {
-            return GetResourceForTimeSpan(TimeUnit.Millisecond, 0);
+            return GetResourceForTimeSpan(TimeUnit.Millisecond, 0, TimeSpanFormatStrategy.Long);
         }
 
-        /// <summary>
-        /// Returns the string representation of the provided TimeSpan
-        /// </summary>
-        /// <param name="timeUnit">Must be less than or equal to TimeUnit.Week</param>
-        /// <param name="unit"></param>
-        /// <returns></returns>
-        /// <exception cref="System.ArgumentOutOfRangeException">Is thrown when timeUnit is larger than TimeUnit.Week</exception>
-        public virtual string TimeSpanHumanize(TimeUnit timeUnit, int unit)
+	    /// <summary>
+	    /// Returns the string representation of the provided TimeSpan
+	    /// </summary>
+	    /// <param name="timeUnit">Must be less than or equal to TimeUnit.Week</param>
+	    /// <param name="unit"></param>
+	    /// <param name="strategy">Optional TimeSpanFormatStrategy, default is Long</param>
+	    /// <returns></returns>
+	    /// <exception cref="System.ArgumentOutOfRangeException">Is thrown when timeUnit is larger than TimeUnit.Week</exception>
+	    public virtual string TimeSpanHumanize(TimeUnit timeUnit, int unit, TimeSpanFormatStrategy strategy = TimeSpanFormatStrategy.Long)
         {
             if (timeUnit > TimeUnit.Week)
                 throw new ArgumentOutOfRangeException("timeUnit", "There's no meaningful way to humanize passed timeUnit.");
 
-            return GetResourceForTimeSpan(timeUnit, unit);
+            return GetResourceForTimeSpan(timeUnit, unit, strategy);
         }
 
         private string GetResourceForDate(TimeUnit unit, Tense timeUnitTense, int count)
@@ -70,9 +71,9 @@ namespace Humanizer.Localisation.Formatters
             return count == 1 ? Format(resourceKey) : Format(resourceKey, count);
         }
 
-        private string GetResourceForTimeSpan(TimeUnit unit, int count)
+        private string GetResourceForTimeSpan(TimeUnit unit, int count, TimeSpanFormatStrategy strategy)
         {
-            string resourceKey = ResourceKeys.TimeSpanHumanize.GetResourceKey(unit, count);
+            string resourceKey = ResourceKeys.TimeSpanHumanize.GetResourceKey(unit, count, strategy);
             return count == 1 ? Format(resourceKey) : Format(resourceKey, count);
         }
 

--- a/src/Humanizer/Localisation/Formatters/IFormatter.cs
+++ b/src/Humanizer/Localisation/Formatters/IFormatter.cs
@@ -28,12 +28,29 @@
         /// <returns>Returns 0 seconds as the string representation of Zero TimeSpan</returns>
         string TimeSpanHumanize_Zero();
 
-        /// <summary>
-        /// Returns the string representation of the provided TimeSpan
-        /// </summary>
-        /// <param name="timeUnit"></param>
-        /// <param name="unit"></param>
-        /// <returns></returns>
-        string TimeSpanHumanize(TimeUnit timeUnit, int unit);
+	    /// <summary>
+	    /// Returns the string representation of the provided TimeSpan
+	    /// </summary>
+	    /// <param name="timeUnit"></param>
+	    /// <param name="unit"></param>
+	    /// <param name="strategy"></param>
+	    /// <returns></returns>
+	    string TimeSpanHumanize(TimeUnit timeUnit, int unit, TimeSpanFormatStrategy strategy = TimeSpanFormatStrategy.Long);
     }
+
+	/// <summary>
+	/// Alternative strategies for formatting TimeSpan
+	/// </summary>
+	public enum TimeSpanFormatStrategy
+	{
+		/// <summary>
+		/// Default strategy giving "day/s", "minute/s", "millisecond/s", etc
+		/// </summary>
+		Long,
+		/// <summary>
+		/// Optional strategy giving "d", "m", "ms", etc
+		/// </summary>
+		Short,
+	}
+
 }

--- a/src/Humanizer/Localisation/ResourceKeys.TimeSpanHumanize.cs
+++ b/src/Humanizer/Localisation/ResourceKeys.TimeSpanHumanize.cs
@@ -1,4 +1,6 @@
-﻿namespace Humanizer.Localisation
+﻿using Humanizer.Localisation.Formatters;
+
+namespace Humanizer.Localisation
 {
     public partial class ResourceKeys
     {
@@ -11,23 +13,26 @@
             /// Examples: TimeSpanHumanize_SingleMinute, TimeSpanHumanize_MultipleHours.
             /// Note: "s" for plural served separately by third part.
             /// </summary>
-            private const string TimeSpanFormat = "TimeSpanHumanize_{0}{1}{2}";
+			private const string TimeSpanFormat = "TimeSpan{0}Humanize_{1}{2}{3}";
             private const string Zero = "TimeSpanHumanize_Zero";
 
-            /// <summary>
-            /// Generates Resource Keys according to convention.
-            /// </summary>
-            /// <param name="unit">Time unit, <see cref="TimeUnit"/>.</param>
-            /// <param name="count">Number of units, default is One.</param>
-            /// <returns>Resource key, like TimeSpanHumanize_SingleMinute</returns>
-            public static string GetResourceKey(TimeUnit unit, int count = 1)
+	        /// <summary>
+	        /// Generates Resource Keys according to convention.
+	        /// </summary>
+	        /// <param name="unit">Time unit, <see cref="TimeUnit"/>.</param>
+	        /// <param name="count">Number of units, default is One.</param>
+			/// <param name="strategy">TimeSpanFormatStrategy to use, default is TimeSpanFormatStrategy.Long</param>
+	        /// <returns>Resource key, like TimeSpanHumanize_SingleMinute</returns>
+	        public static string GetResourceKey(TimeUnit unit, int count = 1, TimeSpanFormatStrategy strategy = TimeSpanFormatStrategy.Long)
             {
                 ValidateRange(count);
 
                 if (count == 0) 
                     return Zero;
 
-                return TimeSpanFormat.FormatWith(count == 1 ? Single : Multiple, unit, count == 1 ? "" : "s");
+	            var strategyInUse = strategy == TimeSpanFormatStrategy.Short ? "Short" : "";
+
+                return TimeSpanFormat.FormatWith(strategyInUse, count == 1 ? Single : Multiple, unit, count == 1 ? "" : "s");
             }
         }
     }

--- a/src/Humanizer/Properties/Resources.resx
+++ b/src/Humanizer/Properties/Resources.resx
@@ -231,4 +231,40 @@
   <data name="DateHumanize_SingleYearFromNow" xml:space="preserve">
     <value>one year from now</value>
   </data>
+  <data name="TimeSpanShortHumanize_MultipleDays" xml:space="preserve">
+    <value>{0}d</value>
+  </data>
+  <data name="TimeSpanShortHumanize_MultipleHours" xml:space="preserve">
+    <value>{0}h</value>
+  </data>
+  <data name="TimeSpanShortHumanize_MultipleMilliseconds" xml:space="preserve">
+    <value>{0}ms</value>
+  </data>
+  <data name="TimeSpanShortHumanize_MultipleMinutes" xml:space="preserve">
+    <value>{0}m</value>
+  </data>
+  <data name="TimeSpanShortHumanize_MultipleSeconds" xml:space="preserve">
+    <value>{0}s</value>
+  </data>
+  <data name="TimeSpanShortHumanize_MultipleWeeks" xml:space="preserve">
+    <value>{0}wk</value>
+  </data>
+  <data name="TimeSpanShortHumanize_SingleDay" xml:space="preserve">
+    <value>1d</value>
+  </data>
+  <data name="TimeSpanShortHumanize_SingleHour" xml:space="preserve">
+    <value>1h</value>
+  </data>
+  <data name="TimeSpanShortHumanize_SingleMillisecond" xml:space="preserve">
+    <value>1ms</value>
+  </data>
+  <data name="TimeSpanShortHumanize_SingleMinute" xml:space="preserve">
+    <value>1m</value>
+  </data>
+  <data name="TimeSpanShortHumanize_SingleSecond" xml:space="preserve">
+    <value>1s</value>
+  </data>
+  <data name="TimeSpanShortHumanize_SingleWeek" xml:space="preserve">
+    <value>1wk</value>
+  </data>
 </root>

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Text;
 using Humanizer.Configuration;
 using Humanizer.Localisation;
+using Humanizer.Localisation.Formatters;
 
 namespace Humanizer
 {
@@ -11,19 +12,20 @@ namespace Humanizer
     /// </summary>
     public static class TimeSpanHumanizeExtensions
     {
-        /// <summary>
-        /// Turns a TimeSpan into a human readable form. E.g. 1 day.
-        /// </summary>
-        /// <param name="timeSpan"></param>
-        /// <param name="precision">The maximum number of time units to return. Defaulted is 1 which means the largest unit is returned</param>
-        /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
-        /// <returns></returns>
-        public static string Humanize(this TimeSpan timeSpan, int precision = 1, CultureInfo culture = null)
+	    /// <summary>
+	    /// Turns a TimeSpan into a human readable form. E.g. 1 day.
+	    /// </summary>
+	    /// <param name="timeSpan"></param>
+	    /// <param name="precision">The maximum number of time units to return. Defaulted is 1 which means the largest unit is returned</param>
+	    /// <param name="culture">Culture to use. If null, current thread's UI culture is used.</param>
+		/// <param name="strategy">TimeSpanFormatStrategy to use. Default is TimeSpanFormatStrategy.Long</param>
+	    /// <returns></returns>
+	    public static string Humanize(this TimeSpan timeSpan, int precision = 1, CultureInfo culture = null, TimeSpanFormatStrategy strategy= TimeSpanFormatStrategy.Long)
         {
             var result = new StringBuilder();
             for (int i = 0; i < precision; i++)
             {
-                var timePart = GetTimePart(timeSpan, culture);
+                var timePart = GetTimePart(timeSpan, culture, strategy);
             
                 if (result.Length > 0)
                     result.Append(", ");
@@ -38,26 +40,26 @@ namespace Humanizer
             return result.ToString();
         }
 
-        private static string GetTimePart(TimeSpan timespan, CultureInfo culture)
+        private static string GetTimePart(TimeSpan timespan, CultureInfo culture, TimeSpanFormatStrategy strategy)
         {
             var formatter = Configurator.GetFormatter(culture);
             if (timespan.Days >= 7)
-                return formatter.TimeSpanHumanize(TimeUnit.Week, timespan.Days/7);
+                return formatter.TimeSpanHumanize(TimeUnit.Week, timespan.Days/7, strategy);
 
             if (timespan.Days >= 1)
-                return formatter.TimeSpanHumanize(TimeUnit.Day, timespan.Days);
+				return formatter.TimeSpanHumanize(TimeUnit.Day, timespan.Days, strategy);
 
             if (timespan.Hours >= 1)
-                return formatter.TimeSpanHumanize(TimeUnit.Hour, timespan.Hours);
+				return formatter.TimeSpanHumanize(TimeUnit.Hour, timespan.Hours, strategy);
 
             if (timespan.Minutes >= 1)
-                return formatter.TimeSpanHumanize(TimeUnit.Minute, timespan.Minutes);
+				return formatter.TimeSpanHumanize(TimeUnit.Minute, timespan.Minutes, strategy);
 
             if (timespan.Seconds >= 1)
-                return formatter.TimeSpanHumanize(TimeUnit.Second, timespan.Seconds);
+				return formatter.TimeSpanHumanize(TimeUnit.Second, timespan.Seconds, strategy);
 
             if (timespan.Milliseconds >= 1)
-                return formatter.TimeSpanHumanize(TimeUnit.Millisecond, timespan.Milliseconds);
+				return formatter.TimeSpanHumanize(TimeUnit.Millisecond, timespan.Milliseconds, strategy);
 
             return formatter.TimeSpanHumanize_Zero();
         }


### PR DESCRIPTION
I needed the ability to get "ms", "s", "h", etc time identifiers.

For example, `TimeSpan.FromHours(2).Humanize()` I'd like to be able to have `"2 days"`or  `"2d"`