### PR TITLE
Added culture specific decimal separator

### DIFF
--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -326,9 +326,12 @@ namespace Humanizer.Bytes
             int num;
             var found = false;
 
+            // Acquiring culture specific decimal separator
+			char decSep = Convert.ToChar(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
+                
             // Pick first non-digit number
             for (num = 0; num < s.Length; num++)
-                if (!(char.IsDigit(s[num]) || s[num] == '.'))
+                if (!(char.IsDigit(s[num]) || s[num] == decSep))
                 {
                     found = true;
                     break;


### PR DESCRIPTION
Added a culture specific decimal separator in the TryParse method of ByteSize.cs to provide correct parsing on systems where the decimal separator is other than ".".