### PR TITLE
Fixes trailing question mark reported in #378.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,5 @@
 ###In Development
-
+ - [#381](https://github.com/MehdiK/Humanizer/pull/381): Fixes trailing question mark reported in #378.
 
 [Commits](https://github.com/MehdiK/Humanizer/compare/v1.33.7...master)
 

--- a/src/Humanizer.Tests/StringDehumanizeTests.cs
+++ b/src/Humanizer.Tests/StringDehumanizeTests.cs
@@ -12,6 +12,9 @@ namespace Humanizer.Tests
         [InlineData("lower case sentence is camelized", "LowerCaseSentenceIsCamelized")]
         [InlineData("AlreadyDehumanizedStringIsUntouched", "AlreadyDehumanizedStringIsUntouched")]
         [InlineData("", "")]
+        [InlineData("A special character is removed?", "ASpecialCharacterIsRemoved")]
+        [InlineData("A special character is removed after a space ?", "ASpecialCharacterIsRemovedAfterASpace")]
+        [InlineData("Internal special characters ?)@ are removed", "InternalSpecialCharactersAreRemoved")]
         public void CanDehumanizeIntoAPascalCaseWord(string input, string expectedResult)
         {
             Assert.Equal(expectedResult, input.Dehumanize());

--- a/src/Humanizer.Tests/StringHumanizeTests.cs
+++ b/src/Humanizer.Tests/StringHumanizeTests.cs
@@ -12,6 +12,12 @@ namespace Humanizer.Tests
         [InlineData("NumberIsAtTheEnd100", "Number is at the end 100")]
         [InlineData("XIsFirstWordInTheSentence", "X is first word in the sentence")]
         [InlineData("XIsFirstWordInTheSentence ThenThereIsASpace", "X is first word in the sentence then there is a space")]
+        [InlineData("ContainsSpecial?)@Characters", "Contains special characters")]
+        [InlineData("a", "A")]
+        [InlineData("A", "A")]
+        [InlineData("?)@", "")]
+        [InlineData("?", "")]
+        [InlineData("", "")]
         public void CanHumanizeStringInPascalCase(string input, string expectedResult)
         {
             Assert.Equal(expectedResult, input.Humanize());

--- a/src/Humanizer/StringHumanizeExtensions.cs
+++ b/src/Humanizer/StringHumanizeExtensions.cs
@@ -26,20 +26,15 @@ namespace Humanizer
 
         static string FromPascalCase(string input)
         {
-            if (input.Length == 1)
-                return Char.ToUpper(input[0]).ToString();
-
-            var result = PascalCaseWordPartsRegex
+            var result = String.Join(" ", PascalCaseWordPartsRegex
                 .Matches(input).Cast<Match>()
                 .Select(match => match.Value.ToCharArray().All(Char.IsUpper) &&
                     (match.Value.Length > 1 || (match.Index > 0 && input[match.Index - 1] == ' ') || match.Value == "I")
                     ? match.Value
-                    : match.Value.ToLower())
-                .Aggregate((res, word) => res + " " + word);
+                    : match.Value.ToLower()));
 
-            result = Char.ToUpper(result[0]) +
-                result.Substring(1, result.Length - 1);
-            return result;
+            return result.Length > 0 ? Char.ToUpper(result[0]) +
+                result.Substring(1, result.Length - 1) : result;
         }
 
         /// <summary>
@@ -53,7 +48,7 @@ namespace Humanizer
             if (input.ToCharArray().All(Char.IsUpper))
                 return input;
 
-            // if input contains a dash or underscore which preceeds or follows a space (or both, i.g. free-standing)
+            // if input contains a dash or underscore which preceeds or follows a space (or both, e.g. free-standing)
             // remove the dash/underscore and run it through FromPascalCase
             if (FreestandingSpacingCharRegex.IsMatch(input))
                 return FromPascalCase(FromUnderscoreDashSeparatedWords(input));


### PR DESCRIPTION
A few new tests demonstrate the problem and the fix.

The problem is the upfront single-character check, which lets a single special character through.

The fix is to let the Regex work on every string, and check for empty Enumerations with String.Join and the final ternary operator.