### PR TITLE
collection formatter generalized to "OxfordStyle" and "RegularStyle"

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,6 +1,7 @@
 ###In Development
  - [#381](https://github.com/MehdiK/Humanizer/pull/381): Fixes trailing question mark reported in #378.
  - [#382](https://github.com/MehdiK/Humanizer/pull/382): Fix 90000th and -thousandth in RussianNumberToWordsConverter.
+ - [#386](https://github.com/MehdiK/Humanizer/pull/386): Collection formatter support for German, Danish, Dutch, Portuguese and Norwegian
 
 [Commits](https://github.com/MehdiK/Humanizer/compare/v1.33.7...master)
 

--- a/src/Humanizer.Tests/Humanizer.Tests.csproj
+++ b/src/Humanizer.Tests/Humanizer.Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Localisation\bn-BD\NumberToWordsTests.cs" />
     <Compile Include="Localisation\bn-BD\TimeSpanHumanizeTests.cs" />
     <Compile Include="Localisation\DefaultFormatterTests.cs" />
+    <Compile Include="Localisation\de\CollectionFormatterTests.cs" />
     <Compile Include="Localisation\nb\DateHumanizeTests.cs" />
     <Compile Include="Localisation\nb\TimeSpanHumanizeTests.cs" />
     <Compile Include="Localisation\cs\DateHumanizeTests.cs" />

--- a/src/Humanizer.Tests/Localisation/de/CollectionFormatterTests.cs
+++ b/src/Humanizer.Tests/Localisation/de/CollectionFormatterTests.cs
@@ -1,12 +1,12 @@
 ﻿using System.Collections.Generic;
 using Xunit;
 
-namespace Humanizer.Tests.Localisation.it
+namespace Humanizer.Tests.Localisation.de
 {
     public class CollectionFormatterTests : AmbientCulture
     {
         public CollectionFormatterTests() 
-            : base("it") 
+            : base("de") 
         {
         }
 
@@ -22,7 +22,7 @@ namespace Humanizer.Tests.Localisation.it
         public void TwoItems()
         {
             var collection = new List<int>(new int[] {1, 2});
-            string humanized = "1 e 2";
+            string humanized = "1 und 2";
             Assert.Equal(humanized, collection.Humanize());
         }
 
@@ -30,7 +30,7 @@ namespace Humanizer.Tests.Localisation.it
         public void MoreThanTwoItems()
         {
             var collection = new List<int>(new int[] {1, 2, 3});
-            string humanized = "1, 2 e 3";
+            string humanized = "1, 2 und 3";
             Assert.Equal(humanized, collection.Humanize());
         }
     }

--- a/src/Humanizer/Configuration/CollectionFormatterRegistry.cs
+++ b/src/Humanizer/Configuration/CollectionFormatterRegistry.cs
@@ -10,6 +10,11 @@ namespace Humanizer.Configuration
             Register("en", new OxfordStyleCollectionFormatter("and"));
             Register("it", new RegularStyleCollectionFormatter("e"));
             Register("de", new RegularStyleCollectionFormatter("und"));
+            Register("dk", new RegularStyleCollectionFormatter("og"));
+            Register("nl", new RegularStyleCollectionFormatter("en"));
+            Register("pt", new RegularStyleCollectionFormatter("e"));
+            Register("nn", new RegularStyleCollectionFormatter("og"));
+            Register("nb", new RegularStyleCollectionFormatter("og"));
         }
     }
 }

--- a/src/Humanizer/Configuration/CollectionFormatterRegistry.cs
+++ b/src/Humanizer/Configuration/CollectionFormatterRegistry.cs
@@ -7,8 +7,9 @@ namespace Humanizer.Configuration
         public CollectionFormatterRegistry()
             : base(new DefaultCollectionFormatter())
         {
-            Register("en", new EnglishCollectionFormatter());
-            Register("it", new ItalianCollectionFormatter());
+            Register("en", new OxfordStyleCollectionFormatter("and"));
+            Register("it", new RegularStyleCollectionFormatter("e"));
+            Register("de", new RegularStyleCollectionFormatter("und"));
         }
     }
 }

--- a/src/Humanizer/Humanizer.csproj
+++ b/src/Humanizer/Humanizer.csproj
@@ -53,9 +53,9 @@
     <Compile Include="CollectionHumanizeExtensions.cs" />
     <Compile Include="Configuration\CollectionFormatterRegistry.cs" />
     <Compile Include="Localisation\CollectionFormatters\DefaultCollectionFormatter.cs" />
-    <Compile Include="Localisation\CollectionFormatters\EnglishCollectionFormatter.cs" />
-    <Compile Include="Localisation\CollectionFormatters\ItalianCollectionFormatter.cs" />
+    <Compile Include="Localisation\CollectionFormatters\RegularStyleCollectionFormatter.cs" />
     <Compile Include="Localisation\CollectionFormatters\ICollectionFormatter.cs" />
+    <Compile Include="Localisation\CollectionFormatters\OxfordStyleCollectionFormatter.cs" />
     <Compile Include="Localisation\Formatters\SerbianFormatter.cs" />
     <Compile Include="Localisation\Formatters\SlovenianFormatter.cs" />
     <Compile Include="Configuration\LocaliserRegistry.cs" />

--- a/src/Humanizer/Localisation/CollectionFormatters/OxfordStyleCollectionFormatter.cs
+++ b/src/Humanizer/Localisation/CollectionFormatters/OxfordStyleCollectionFormatter.cs
@@ -4,14 +4,14 @@ using System.Linq;
 
 namespace Humanizer.Localisation.CollectionFormatters
 {
-    internal class EnglishCollectionFormatter : DefaultCollectionFormatter
+    internal class OxfordStyleCollectionFormatter : DefaultCollectionFormatter
     {
-        public EnglishCollectionFormatter()
+        public OxfordStyleCollectionFormatter(string defaultDeparator)
         {
-            DefaultSeparator = "and";
+            DefaultSeparator = defaultDeparator ?? "and";
         }
 
-        public override string Humanize<T>(IEnumerable<T> collection, Func<T, String> objectFormatter, String separator)
+        public override string Humanize<T>(IEnumerable<T> collection, Func<T, string> objectFormatter, String separator)
         {
             if (collection == null)
                 throw new ArgumentException("collection");
@@ -29,9 +29,9 @@ namespace Humanizer.Localisation.CollectionFormatters
             string formatString = count > 2 ? "{0}, {1} {2}" : "{0} {1} {2}";
 
             return String.Format(formatString,
-                                 String.Join(", ", enumerable.Take(count - 1).Select(objectFormatter)),
-                                 separator,
-                                 objectFormatter(enumerable.Skip(count - 1).First()));
+                String.Join(", ", enumerable.Take(count - 1).Select(objectFormatter)),
+                separator,
+                objectFormatter(enumerable.Skip(count - 1).First()));
         }
     }
 }

--- a/src/Humanizer/Localisation/CollectionFormatters/OxfordStyleCollectionFormatter.cs
+++ b/src/Humanizer/Localisation/CollectionFormatters/OxfordStyleCollectionFormatter.cs
@@ -6,9 +6,9 @@ namespace Humanizer.Localisation.CollectionFormatters
 {
     internal class OxfordStyleCollectionFormatter : DefaultCollectionFormatter
     {
-        public OxfordStyleCollectionFormatter(string defaultDeparator)
+        public OxfordStyleCollectionFormatter(string defaultSeparator)
         {
-            DefaultSeparator = defaultDeparator ?? "and";
+            DefaultSeparator = defaultSeparator ?? "and";
         }
 
         public override string Humanize<T>(IEnumerable<T> collection, Func<T, string> objectFormatter, String separator)

--- a/src/Humanizer/Localisation/CollectionFormatters/RegularStyleCollectionFormatter.cs
+++ b/src/Humanizer/Localisation/CollectionFormatters/RegularStyleCollectionFormatter.cs
@@ -6,9 +6,9 @@ namespace Humanizer.Localisation.CollectionFormatters
 {
     internal class RegularStyleCollectionFormatter : DefaultCollectionFormatter
     {
-        public RegularStyleCollectionFormatter(string defaultDeparator)
+        public RegularStyleCollectionFormatter(string defaultSeparator)
         {
-            DefaultSeparator = defaultDeparator ?? "and";
+            DefaultSeparator = defaultSeparator ?? "and";
         }
 
         public override string Humanize<T>(IEnumerable<T> collection, Func<T, String> objectFormatter, String separator)

--- a/src/Humanizer/Localisation/CollectionFormatters/RegularStyleCollectionFormatter.cs
+++ b/src/Humanizer/Localisation/CollectionFormatters/RegularStyleCollectionFormatter.cs
@@ -4,12 +4,11 @@ using System.Linq;
 
 namespace Humanizer.Localisation.CollectionFormatters
 {
-    internal class ItalianCollectionFormatter : EnglishCollectionFormatter
+    internal class RegularStyleCollectionFormatter : DefaultCollectionFormatter
     {
-        public ItalianCollectionFormatter()
-            : base()
+        public RegularStyleCollectionFormatter(string defaultDeparator)
         {
-            DefaultSeparator = "e";
+            DefaultSeparator = defaultDeparator ?? "and";
         }
 
         public override string Humanize<T>(IEnumerable<T> collection, Func<T, String> objectFormatter, String separator)


### PR DESCRIPTION
This change is regarding the concatenation of multiple items with comma and e.g. "and". See:

new []{"Peter", "Paul", "Mary"} => EN => "Peter, Paul, and Mary"  (if you use Oxford style)
new []{"Peter", "Paul", "Mary"} => EN => "Peter, Paul and Mary"   (if you dont use Oxford style)
new []{"Peter", "Paul", "Mary"} => DE => "Peter, Paul and Mary"   (this is how it works in italian and german)

The English and Italian version got generaltized to "OxfordSyle" and "RegularStyle". The registry now uses these base classes with a constructor parameter to get the default separator.
The registry now registers a german collection formatter.
