### PR TITLE
Changed Humanizer.nuspec to support Xamarin platforms

### DIFF
--- a/src/Humanizer.nuspec
+++ b/src/Humanizer.nuspec
@@ -14,6 +14,6 @@
     <licenseUrl>https://github.com/MehdiK/Humanizer/blob/master/LICENSE</licenseUrl>
   </metadata>
   <files>
-    <file src="Humanizer\bin\Release\**" target="lib\portable-win+net40+sl50+wp8+wpa81" />
+    <file src="Humanizer\bin\Release\**" target="lib\portable-win+net40+sl50+wp8+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />
   </files>
 </package>


### PR DESCRIPTION
I changed the nuspec file to add support for Xamarin platforms.  The project file already supported them because it did not include a profile that excluded them.  With this change, Xamarin users can also install Humanizer from NuGet.