### PR TITLE
Add rule for is/are

### DIFF
--- a/src/Humanizer.Tests/InflectorTests.cs
+++ b/src/Humanizer.Tests/InflectorTests.cs
@@ -250,6 +250,8 @@ namespace Humanizer.Tests
             yield return new object[] {"wave","waves"};
 
             yield return new object[] {"campus", "campuses"};
+
+            yield return new object[] { "is", "are" };
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/Humanizer/InflectorExtensions.cs
+++ b/src/Humanizer/InflectorExtensions.cs
@@ -71,6 +71,7 @@ namespace Humanizer
             AddPlural("^(ox)$", "$1en");
             AddPlural("(quiz)$", "$1zes");
             AddPlural("(campus)$", "$1es");
+            AddPlural("^is$", "are");
 
             AddSingular("s$", "");
             AddSingular("(n)ews$", "$1ews");
@@ -97,6 +98,7 @@ namespace Humanizer
             AddSingular("(matr)ices$", "$1ix");
             AddSingular("(quiz)zes$", "$1");
             AddSingular("(campus)es$", "$1");
+            AddSingular("^are$", "is");
 
             AddIrregular("person", "people");
             AddIrregular("man", "men");


### PR DESCRIPTION
I don't know whether this belongs in the same area or not, but we'd like the functionality to extend to the following kinds of sentences:

There is 1 case
There are 5 cases

We can obviously already to "case".ToQuantity(5) to get cases, but we'd like to be able to do the auxiliary verb (is/are) as well.

I've added those entries in but would be happy to get feedback on whether this is the right place or not.