### PR TITLE
Fix typo in source: StringExentions -> StringExtensions

### DIFF
--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
@@ -490,7 +490,7 @@ public class StringDehumanizeExtensions
     public string Dehumanize(string input) { }
 }
 
-public class StringExentions
+public class StringExtentions
 {
     public string FormatWith(string format, object[] args) { }
     public string FormatWith(string format, System.IFormatProvider provider, object[] args) { }

--- a/src/Humanizer/Humanizer.csproj
+++ b/src/Humanizer/Humanizer.csproj
@@ -143,7 +143,7 @@
     <Compile Include="OnNoMatch.cs" />
     <Compile Include="NoMatchFoundException.cs" />
     <Compile Include="RomanNumeralExtensions.cs" />
-    <Compile Include="StringExentions.cs" />
+    <Compile Include="StringExtentions.cs" />
     <Compile Include="ToQuantityExtensions.cs" />
     <Compile Include="Transformer\To.cs" />
     <Compile Include="Transformer\IStringTransformer.cs" />

--- a/src/Humanizer/StringExtentions.cs
+++ b/src/Humanizer/StringExtentions.cs
@@ -5,7 +5,7 @@ namespace Humanizer
     /// <summary>
     /// Extension methods for String type.
     /// </summary>
-    public static class StringExentions
+    public static class StringExtentions
     {
         /// <summary>
         /// Extension method to format string with passed arguments. Current thread's current culture is used


### PR DESCRIPTION
Replaced all occurrences of the typo 'StringExentions'