### PR TITLE
point the licenseUrl to the raw license

### DIFF
--- a/src/Humanizer.nuspec
+++ b/src/Humanizer.nuspec
@@ -11,7 +11,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Humanizer meets all your .NET needs for manipulating and displaying strings, enums, dates, times, timespans, numbers and quantities</description>
     <copyright>Copyright 2012-2014  Mehdi Khalili</copyright>
-    <licenseUrl>https://github.com/MehdiK/Humanizer/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://raw.githubusercontent.com/MehdiK/Humanizer/master/LICENSE</licenseUrl>
   </metadata>
   <files>
     <file src="Humanizer\bin\Release\**" target="lib\portable-win+net40+sl50+wp8+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10" />


### PR DESCRIPTION
This is based on the following email I got today:

>> Salutations. I'm in the process of doing our quarterly review of packages we use for our program. I'm using a little PowerShell script to download the license files for review.
Thank you for linking the license, but would you consider switching to the raw version? The main reason is that GitHub adds a lot of HTML data (including randomly changing values) which makes BeyondCompare difficult when trying to review license changes.