### PR TITLE
Fix typo (again) StringExtentions -> StringExtensions

### DIFF
--- a/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
+++ b/src/Humanizer.Tests/ApiApprover/PublicApiApprovalTest.approve_public_api.approved.txt
@@ -490,7 +490,7 @@ public class StringDehumanizeExtensions
     public string Dehumanize(string input) { }
 }
 
-public class StringExtentions
+public class StringExtensions
 {
     public string FormatWith(string format, object[] args) { }
     public string FormatWith(string format, System.IFormatProvider provider, object[] args) { }

--- a/src/Humanizer/Humanizer.csproj
+++ b/src/Humanizer/Humanizer.csproj
@@ -143,7 +143,7 @@
     <Compile Include="OnNoMatch.cs" />
     <Compile Include="NoMatchFoundException.cs" />
     <Compile Include="RomanNumeralExtensions.cs" />
-    <Compile Include="StringExtentions.cs" />
+    <Compile Include="StringExtensions.cs" />
     <Compile Include="ToQuantityExtensions.cs" />
     <Compile Include="Transformer\To.cs" />
     <Compile Include="Transformer\IStringTransformer.cs" />

--- a/src/Humanizer/StringExtensions.cs
+++ b/src/Humanizer/StringExtensions.cs
@@ -5,7 +5,7 @@ namespace Humanizer
     /// <summary>
     /// Extension methods for String type.
     /// </summary>
-    public static class StringExtentions
+    public static class StringExtensions
     {
         /// <summary>
         /// Extension method to format string with passed arguments. Current thread's current culture is used


### PR DESCRIPTION
Second attempt, original (#421) introduced another typo.