### PR TITLE
Fix #430: Added the 'xunit.runner.visualstudio' nuget package to the test project

### DIFF
--- a/src/Humanizer.Tests/Humanizer.Tests.csproj
+++ b/src/Humanizer.Tests/Humanizer.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -14,6 +15,7 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>b1075e02</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -217,6 +219,12 @@
     <Folder Include="Inflections\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Humanizer.Tests/packages.config
+++ b/src/Humanizer.Tests/packages.config
@@ -5,4 +5,5 @@
   <package id="ApprovalUtilities" version="3.0.5" targetFramework="net40" />
   <package id="xunit" version="1.9.1" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.1" targetFramework="net40" />
+  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This nuget package allows running and debugging tests directly from inside Visual Studio (requires 2012 or higher). The screenshots below shows all the tests passing from inside Visual Studio and from `build.cmd`. See #430 for more information about the test count differences

![image](https://cloud.githubusercontent.com/assets/1189909/8346927/79f1639a-1ab8-11e5-9bcc-407460e13892.png)

![image](https://cloud.githubusercontent.com/assets/1189909/8346931/8603c04c-1ab8-11e5-90ca-47d42da8a5d8.png)
