### PR TITLE
fixes #426 adds support for 0 bytes, fixes #434 for TimeSpan < 1hr formatted as 1hr + Xmins

### DIFF
--- a/src/Humanizer.Tests/Bytes/ByteSizeExtensionsTests.cs
+++ b/src/Humanizer.Tests/Bytes/ByteSizeExtensionsTests.cs
@@ -130,6 +130,8 @@ namespace Humanizer.Tests.Bytes
         }
 
         [Theory]
+        [InlineData(0, null, "0 b")]
+        [InlineData(0, "GB", "0 GB")]
         [InlineData(2, null, "2 GB")]
         [InlineData(2, "MB", "2048 MB")]
         [InlineData(2.123, "#.##", "2.12 GB")]
@@ -195,6 +197,8 @@ namespace Humanizer.Tests.Bytes
         }
 
         [Theory]
+        [InlineData(0, null, "0 b")]
+        [InlineData(0, "MB", "0 MB")]
         [InlineData(2, null, "2 MB")]
         [InlineData(2, "KB", "2048 KB")]
         [InlineData(2.123, "#", "2 MB")]
@@ -260,6 +264,8 @@ namespace Humanizer.Tests.Bytes
         }
 
         [Theory]
+        [InlineData(0, null, "0 b")]
+        [InlineData(0, "KB", "0 KB")]
         [InlineData(2, null, "2 KB")]
         [InlineData(2, "B", "2048 B")]
         [InlineData(2.123, "#.####", "2.123 KB")]
@@ -325,6 +331,8 @@ namespace Humanizer.Tests.Bytes
         }
 
         [Theory]
+        [InlineData(0, null, "0 b")]
+        [InlineData(0, "B", "0 B")]
         [InlineData(2, null, "2 B")]
         [InlineData(2000, "KB", "1.95 KB")]
         [InlineData(2123, "#.##", "2.07 KB")]
@@ -383,6 +391,8 @@ namespace Humanizer.Tests.Bytes
         }
 
         [Theory]
+        [InlineData(0, null, "0 b")]
+        [InlineData(0, "b", "0 b")]
         [InlineData(2, null, "2 b")]
         [InlineData(12, "B", "1.5 B")]
         [InlineData(10000, "#.# KB", "1.2 KB")]

--- a/src/Humanizer.Tests/Bytes/ByteSizeExtensionsTests.cs
+++ b/src/Humanizer.Tests/Bytes/ByteSizeExtensionsTests.cs
@@ -336,6 +336,9 @@ namespace Humanizer.Tests.Bytes
         [InlineData(2, null, "2 B")]
         [InlineData(2000, "KB", "1.95 KB")]
         [InlineData(2123, "#.##", "2.07 KB")]
+        [InlineData(10000000, "KB", "9765.63 KB")]
+        [InlineData(10000000, "#,##0 KB", "9,766 KB")]
+        [InlineData(10000000, "#,##0.# KB", "9,765.6 KB")]
         public void HumanizesBytes(double input, string format, string expectedValue)
         {
             Assert.Equal(expectedValue, input.Bytes().Humanize(format));

--- a/src/Humanizer.Tests/TimeSpanHumanizeTests.cs
+++ b/src/Humanizer.Tests/TimeSpanHumanizeTests.cs
@@ -56,6 +56,7 @@ namespace Humanizer.Tests
             Assert.Equal(expected, actual);
         }
 
+
         [Theory]
         [InlineData(135, "2 minutes")]
         [InlineData(60, "1 minute")]
@@ -174,6 +175,16 @@ namespace Humanizer.Tests
         public void TimeSpanWithPrecesion(int milliseconds, int precesion, string expected)
         {
             var actual = TimeSpan.FromMilliseconds(milliseconds).Humanize(precesion);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(50)]
+        [InlineData(52)]
+        public void TimeSpanWithMinAndMaxUnits_DoesNotReportExcessiveTime(int minutes)
+        {
+            var actual = TimeSpan.FromMinutes(minutes).Humanize(2, null, TimeUnit.Hour, TimeUnit.Minute);
+            var expected = TimeSpan.FromMinutes(minutes).Humanize(2);
             Assert.Equal(expected, actual);
         }
 

--- a/src/Humanizer/Bytes/ByteSize.cs
+++ b/src/Humanizer/Bytes/ByteSize.cs
@@ -157,7 +157,7 @@ namespace Humanizer.Bytes
         public string ToString(string format)
         {
             if (!format.Contains("#") && !format.Contains("0"))
-                format = "#.## " + format;
+                format = "0.## " + format;
 
             Func<string, bool> has = s => format.IndexOf(s, StringComparison.CurrentCultureIgnoreCase) != -1;
             Func<double, string> output = n => n.ToString(format);

--- a/src/Humanizer/TimeSpanHumanizeExtensions.cs
+++ b/src/Humanizer/TimeSpanHumanizeExtensions.cs
@@ -142,7 +142,7 @@ namespace Humanizer
             {
                 try
                 {
-                    return Convert.ToInt32(totalTimeNumberOfUnits);
+                    return (int)totalTimeNumberOfUnits;
                 }
                 catch
                 {


### PR DESCRIPTION
modified the default format string in ByteSize.Format to handle 0 values. Added many unit tests to validate behavior for when Format is explicit with unit (b, B, KB, MB, GB) and implicit using null.