### PR TITLE
Implement Finnish number to words converter and tests

### DIFF
--- a/src/Humanizer.Tests/Humanizer.Tests.csproj
+++ b/src/Humanizer.Tests/Humanizer.Tests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Localisation\bn-BD\TimeSpanHumanizeTests.cs" />
     <Compile Include="Localisation\DefaultFormatterTests.cs" />
     <Compile Include="Localisation\de\CollectionFormatterTests.cs" />
+    <Compile Include="Localisation\fi-FI\NumberToWordsTests.cs" />
     <Compile Include="Localisation\hr\DateHumanizeTests.cs" />
     <Compile Include="Localisation\nb\DateHumanizeTests.cs" />
     <Compile Include="Localisation\nb\TimeSpanHumanizeTests.cs" />

--- a/src/Humanizer.Tests/Localisation/fi-FI/NumberToWordsTests.cs
+++ b/src/Humanizer.Tests/Localisation/fi-FI/NumberToWordsTests.cs
@@ -1,0 +1,72 @@
+﻿using Xunit;
+using Xunit.Extensions;
+
+namespace Humanizer.Tests.Localisation.fiFI
+{
+    public class NumberToWordsTests : AmbientCulture
+    {
+        public NumberToWordsTests() : base("fi-Fi") { }
+
+        [Theory]
+        [InlineData(0, "nolla")]
+        [InlineData(1, "yksi")]
+        [InlineData(11, "yksitoista")]
+        [InlineData(15, "viisitoista")]
+        [InlineData(19, "yhdeksäntoista")]
+        [InlineData(20, "kaksikymmentä")]
+        [InlineData(25, "kaksikymmentäviisi")]
+        [InlineData(50, "viisikymmentä")]
+        [InlineData(90, "yhdeksänkymmentä")]
+        [InlineData(100, "sata")]
+        [InlineData(101, "satayksi")]
+        [InlineData(345, "kolmesataaneljäkymmentäviisi")]
+        [InlineData(678, "kuusisataaseitsemänkymmentäkahdeksan")]
+        [InlineData(1000, "tuhat")]
+        [InlineData(1001, "tuhat yksi")]
+        [InlineData(1234, "tuhat kaksisataakolmekymmentäneljä")]
+        [InlineData(4567, "neljätuhatta viisisataakuusikymmentäseitsemän")]
+        [InlineData(10000, "kymmenentuhatta")]
+        [InlineData(100000, "satatuhatta")]
+        [InlineData(1000000, "miljoona")]
+        [InlineData(10000000, "kymmenenmiljoonaa")]
+        [InlineData(100000000, "satamiljoonaa")]
+        [InlineData(1000000000, "miljardi")]
+        [InlineData(2147483647, "kaksimiljardia sataneljäkymmentäseitsemänmiljoonaa neljäsataakahdeksankymmentäkolmetuhatta kuusisataaneljäkymmentäseitsemän")]  // int.MaxValue
+        [InlineData(-2147483647, "miinus kaksimiljardia sataneljäkymmentäseitsemänmiljoonaa neljäsataakahdeksankymmentäkolmetuhatta kuusisataaneljäkymmentäseitsemän")]  // int.MinValue + 1
+        public void ToWords(int number, string expected)
+        {
+            Assert.Equal(expected, number.ToWords());
+        }
+
+        [Theory]
+        [InlineData(0, "nollas")]
+        [InlineData(1, "ensimmäinen")]
+        [InlineData(2, "toinen")]
+        [InlineData(10, "kymmenes")]
+        [InlineData(11, "yhdestoista")]
+        [InlineData(12, "kahdestoista")]
+        [InlineData(19, "yhdeksästoista")]
+        [InlineData(20, "kahdeskymmenes")]
+        [InlineData(21, "kahdeskymmenesensimmäinen")]
+        [InlineData(22, "kahdeskymmenestoinen")]
+        [InlineData(28, "kahdeskymmeneskahdeksas")]
+        [InlineData(75, "seitsemäskymmenesviides")]
+        [InlineData(100, "sadas")]
+        [InlineData(101, "sadasensimmäinen")]
+        [InlineData(111, "sadasyhdestoista")]
+        [InlineData(1000, "tuhannes")]
+        [InlineData(1101, "tuhannessadasensimmäinen")]
+        [InlineData(10000, "kymmenestuhannes")]
+        [InlineData(100000, "sadastuhannes")]
+        [InlineData(1000000, "miljoonas")]
+        [InlineData(10000000, "kymmenesmiljoonas")]
+        [InlineData(100000000, "sadasmiljoonas")]
+        [InlineData(1000000000, "miljardis")]
+        [InlineData(1000000001, "miljardisensimmäinen")]
+        [InlineData(2147483647, "kahdesmiljardissadasneljäskymmenesseitsemäsmiljoonasneljässadaskahdeksaskymmeneskolmastuhanneskuudessadasneljäskymmenesseitsemäs")] // int.MaxValue
+        public void ToOrdinalWords(int number, string expected)
+        {
+            Assert.Equal(expected, number.ToOrdinalWords());
+        }
+    }
+}

--- a/src/Humanizer/Configuration/NumberToWordsConverterRegistry.cs
+++ b/src/Humanizer/Configuration/NumberToWordsConverterRegistry.cs
@@ -15,6 +15,7 @@ namespace Humanizer.Configuration
             Register("pl", (culture) => new PolishNumberToWordsConverter(culture));
             Register("pt-BR", new BrazilianPortugueseNumberToWordsConverter());
             Register("ru", new RussianNumberToWordsConverter());
+            Register("fi", new FinnishNumberToWordsConverter());
             Register("fr", new FrenchNumberToWordsConverter());
             Register("nl", new DutchNumberToWordsConverter());
             Register("he", (culture) => new HebrewNumberToWordsConverter(culture));

--- a/src/Humanizer/Humanizer.csproj
+++ b/src/Humanizer/Humanizer.csproj
@@ -83,6 +83,7 @@
     <Compile Include="GrammaticalGender.cs" />
     <Compile Include="Localisation\GrammaticalNumber\RussianGrammaticalNumber.cs" />
     <Compile Include="Localisation\GrammaticalNumber\RussianGrammaticalNumberDetector.cs" />
+    <Compile Include="Localisation\NumberToWords\FinnishNumberToWordsConverter.cs" />
     <Compile Include="Localisation\NumberToWords\GenderedNumberToWordsConverter.cs" />
     <Compile Include="Localisation\NumberToWords\GenderlessNumberToWordsConverter.cs" />
     <Compile Include="Localisation\NumberToWords\SerbianCyrlNumberToWordsConverter.cs" />

--- a/src/Humanizer/Localisation/NumberToWords/FinnishNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/FinnishNumberToWordsConverter.cs
@@ -1,0 +1,144 @@
+﻿using System.Collections.Generic;
+
+namespace Humanizer.Localisation.NumberToWords
+{
+    internal class FinnishNumberToWordsConverter : GenderlessNumberToWordsConverter
+    {
+        private static readonly string[] UnitsMap = { "nolla", "yksi", "kaksi", "kolme", "neljä", "viisi", "kuusi", "seitsemän", "kahdeksan", "yhdeksän", "kymmenen"};
+        private static readonly string[] OrdinalUnitsMap = {"nollas", "ensimmäinen", "toinen", "kolmas", "neljäs", "viides", "kuudes", "seitsemäs", "kahdeksas", "yhdeksäs", "kymmenes"};
+
+        private static readonly Dictionary<int, string> OrdinalExceptions = new Dictionary<int, string>
+        {
+            {1, "yhdes" },
+            {2, "kahdes" }
+        };
+
+        public override string Convert(int number)
+        {
+            if (number < 0)
+                return string.Format("miinus {0}", Convert(-number));
+
+            if (number == 0)
+                return UnitsMap[0];
+
+            var parts = new List<string>();
+
+            if ((number / 1000000000) > 0)
+            {
+                parts.Add(number/1000000000 == 1
+                    ? "miljardi "
+                    : string.Format("{0}miljardia ", Convert(number/1000000000)));
+
+                number %= 1000000000;
+            }
+
+            if ((number / 1000000) > 0)
+            {
+                parts.Add(number/1000000 == 1
+                    ? "miljoona "
+                    : string.Format("{0}miljoonaa ", Convert(number/1000000)));
+
+                number %= 1000000;
+            }
+
+            if ((number / 1000) > 0)
+            {
+                parts.Add(number/1000 == 1
+                    ? "tuhat "
+                    : string.Format("{0}tuhatta ", Convert(number/1000)));
+
+                number %= 1000;
+            }
+
+            if ((number / 100) > 0)
+            {
+                parts.Add(number/100 == 1
+                    ? "sata"
+                    : string.Format("{0}sataa", Convert(number/100)));
+
+                number %= 100;
+            }
+
+            if (number >= 20 && (number / 10) > 0)
+            {
+                parts.Add(string.Format("{0}kymmentä", Convert(number / 10)));
+                number %= 10;
+            }
+            else if (number > 10 && number < 20)
+                parts.Add(string.Format("{0}toista", UnitsMap[number%10]));
+
+            if (number > 0 && number <= 10)
+                parts.Add(UnitsMap[number]);
+
+            return string.Join("", parts).Trim();
+        }
+
+        private string GetOrdinalUnit(int number, bool useExceptions)
+        {
+            if (useExceptions && OrdinalExceptions.ContainsKey(number))
+            {
+                return OrdinalExceptions[number];
+            }
+
+            return OrdinalUnitsMap[number];
+        }
+
+        private string ToOrdinal(int number, bool useExceptions)
+        {
+            if (number == 0)
+                return OrdinalUnitsMap[0];
+
+            var parts = new List<string>();
+
+            if ((number / 1000000000) > 0)
+            {
+                var fraction = number / 1000000000;
+                parts.Add(string.Format("{0}miljardis", fraction == 1 ? "" : ToOrdinal(fraction, true)));
+
+                number %= 1000000000;
+            }
+
+            if ((number / 1000000) > 0)
+            {
+                var fraction = number / 1000000;
+                parts.Add(string.Format("{0}miljoonas", fraction == 1 ? "" : ToOrdinal(fraction, true)));
+
+                number %= 1000000;
+            }
+
+            if ((number / 1000) > 0)
+            {
+                var fraction = number / 1000;
+                parts.Add(string.Format("{0}tuhannes", fraction == 1 ? "" : ToOrdinal(fraction, true)));
+
+                number %= 1000;
+            }
+
+            if ((number / 100) > 0)
+            {
+                var fraction = number / 100;
+                parts.Add(string.Format("{0}sadas", fraction == 1 ? "" : ToOrdinal(fraction, true)));
+
+                number %= 100;
+            }
+
+            if (number >= 20 && (number / 10) > 0)
+            {
+                parts.Add(string.Format("{0}kymmenes", ToOrdinal(number / 10, true)));
+                number %= 10;
+            }
+            else if (number > 10 && number < 20)
+                parts.Add(string.Format("{0}toista", GetOrdinalUnit(number % 10, true)));
+
+            if (number > 0 && number <= 10)
+                parts.Add(GetOrdinalUnit(number, useExceptions));
+
+            return string.Join("", parts);
+        }
+
+        public override string ConvertToOrdinal(int number)
+        {
+            return ToOrdinal(number, false);
+        }
+    }
+}

--- a/src/Humanizer/Localisation/NumberToWords/FinnishNumberToWordsConverter.cs
+++ b/src/Humanizer/Localisation/NumberToWords/FinnishNumberToWordsConverter.cs
@@ -25,36 +25,36 @@ namespace Humanizer.Localisation.NumberToWords
 
             if ((number / 1000000000) > 0)
             {
-                parts.Add(number/1000000000 == 1
+                parts.Add(number / 1000000000 == 1
                     ? "miljardi "
-                    : string.Format("{0}miljardia ", Convert(number/1000000000)));
+                    : string.Format("{0}miljardia ", Convert(number / 1000000000)));
 
                 number %= 1000000000;
             }
 
             if ((number / 1000000) > 0)
             {
-                parts.Add(number/1000000 == 1
+                parts.Add(number / 1000000 == 1
                     ? "miljoona "
-                    : string.Format("{0}miljoonaa ", Convert(number/1000000)));
+                    : string.Format("{0}miljoonaa ", Convert(number / 1000000)));
 
                 number %= 1000000;
             }
 
             if ((number / 1000) > 0)
             {
-                parts.Add(number/1000 == 1
+                parts.Add(number / 1000 == 1
                     ? "tuhat "
-                    : string.Format("{0}tuhatta ", Convert(number/1000)));
+                    : string.Format("{0}tuhatta ", Convert(number / 1000)));
 
                 number %= 1000;
             }
 
             if ((number / 100) > 0)
             {
-                parts.Add(number/100 == 1
+                parts.Add(number / 100 == 1
                     ? "sata"
-                    : string.Format("{0}sataa", Convert(number/100)));
+                    : string.Format("{0}sataa", Convert(number / 100)));
 
                 number %= 100;
             }
@@ -65,7 +65,7 @@ namespace Humanizer.Localisation.NumberToWords
                 number %= 10;
             }
             else if (number > 10 && number < 20)
-                parts.Add(string.Format("{0}toista", UnitsMap[number%10]));
+                parts.Add(string.Format("{0}toista", UnitsMap[number % 10]));
 
             if (number > 0 && number <= 10)
                 parts.Add(UnitsMap[number]);
@@ -92,33 +92,25 @@ namespace Humanizer.Localisation.NumberToWords
 
             if ((number / 1000000000) > 0)
             {
-                var fraction = number / 1000000000;
-                parts.Add(string.Format("{0}miljardis", fraction == 1 ? "" : ToOrdinal(fraction, true)));
-
+                parts.Add(string.Format("{0}miljardis", (number / 1000000000) == 1 ? "" : ToOrdinal(number / 1000000000, true)));
                 number %= 1000000000;
             }
 
             if ((number / 1000000) > 0)
             {
-                var fraction = number / 1000000;
-                parts.Add(string.Format("{0}miljoonas", fraction == 1 ? "" : ToOrdinal(fraction, true)));
-
+                parts.Add(string.Format("{0}miljoonas", (number / 1000000) == 1 ? "" : ToOrdinal(number / 1000000, true)));
                 number %= 1000000;
             }
 
             if ((number / 1000) > 0)
             {
-                var fraction = number / 1000;
-                parts.Add(string.Format("{0}tuhannes", fraction == 1 ? "" : ToOrdinal(fraction, true)));
-
+                parts.Add(string.Format("{0}tuhannes", (number / 1000) == 1 ? "" : ToOrdinal(number / 1000, true)));
                 number %= 1000;
             }
 
             if ((number / 100) > 0)
             {
-                var fraction = number / 100;
-                parts.Add(string.Format("{0}sadas", fraction == 1 ? "" : ToOrdinal(fraction, true)));
-
+                parts.Add(string.Format("{0}sadas", (number / 100) == 1 ? "" : ToOrdinal(number / 100, true)));
                 number %= 100;
             }
 


### PR DESCRIPTION
I've implemented a converter for Finnish language number to words conversion, for both cardinal and ordinal numbers. I've included 50 unit tests, 25 for both kinds.

The implementation is fairly straight-forward, as Finnish numerals are highly systematic. While all of the results produced by the converter are linguistically valid, stylistically perfect conversion is hard if not impossible to do, especially when dealing with large (ordinal) numbers, since they are seldom spelled out.

I modelled the algorithm and the style after the English and the French converters. Cardinal and ordinal numbers are implemented as completely separate methods, which causes some code duplication, but results in cleaner and easier to understand code. There are a few style-related issues I'll have to fix, but other than that I think this feature is pretty much finished.