### PR TITLE
Add support of metric numeral expression. fixes #456

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ Humanizer meets all your .NET needs for manipulating and displaying strings, enu
    - [Number to words](#number-to-words)
    - [Number to ordinal words](#number-to-ordinal-words)
    - [Roman numerals](#roman-numerals)
+   - [Metric numerals](#metric-numerals)
    - [ByteSize](#bytesize)
  - [Mix this into your framework to simplify your life](#mix-this-into-your-framework-to-simplify-your-life)
  - [How to contribute?](#how-to-contribute)
@@ -743,6 +744,27 @@ Also the reverse operation using the `FromRoman` extension.
 "III".FromRoman() => 3
 "IV".FromRoman() => 4
 "V".FromRoman() => 5
+```
+
+###<a id="metric-numerals">Metric numerals</a>
+Humanizer can change numbers to Metric numerals using the `ToMetric` extension. The numbers 1, 1230 and 0.1 can be expressed in Metric numerals as follows:
+
+```C#
+1d.ToMetric() => "1"
+1230d.ToMetric() => "1.23k"
+0.1d.ToMetric() => "100m"
+```
+
+Also the reverse operation using the `FromMetric` extension.
+
+```C#
+1d.ToMetric() => "1"
+1230d.ToMetric() => "1.23k"
+0.1d.ToMetric() => "100m"
+
+"1".FromMetric() => 1
+"1.23k".FromMetric() => 1230
+"100m".FromMetric() => 0.1
 ```
 
 ###<a id="bytesize">ByteSize</a>

--- a/src/Humanizer.Tests/Humanizer.Tests.csproj
+++ b/src/Humanizer.Tests/Humanizer.Tests.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Localisation\zh-Hant\TimeSpanHumanizeTests.cs" />
     <Compile Include="Localisation\zh-CN\DateHumanizeTests.cs" />
     <Compile Include="Localisation\zh-CN\TimeSpanHumanizeTests.cs" />
+    <Compile Include="MetricNumeralTests.cs" />
     <Compile Include="ResourceKeyTests.cs" />
     <Compile Include="RomanNumeralTests.cs" />
     <Compile Include="StringExtensionsTests.cs" />

--- a/src/Humanizer.Tests/MetricNumeralTests.cs
+++ b/src/Humanizer.Tests/MetricNumeralTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using Xunit;
 using Xunit.Extensions;
 
@@ -30,6 +31,8 @@ namespace Humanizer.Tests
                         Assert.Equal(expected, input.FromMetric());
                 }
 
+
+
                 [Fact]
                 public void TestAllSymbols()
                 {
@@ -49,6 +52,27 @@ namespace Humanizer.Tests
                                 b &= c;
                         }
                         Assert.True(b);
+                }
+
+                [Theory]
+                [InlineData(-9)]
+                [InlineData(-3)]
+                [InlineData(-2)]
+                [InlineData(-1)]
+                [InlineData(0)]
+                [InlineData(1)]
+                [InlineData(2)]
+                [InlineData(3)]
+                [InlineData(9)]
+                public void TestAllSymbolsAsInt(int exponent)
+                {
+                        var origin = Convert.ToInt32(Math.Pow(10, exponent));
+                        var isEquals = Equals(
+                                origin.ToString("0.##E+0", CultureInfo.InvariantCulture),
+                                origin.ToMetric().FromMetric().ToString("0.##E+0", CultureInfo.InvariantCulture));
+                        if (!isEquals)
+                                Debugger.Break();
+                        Assert.True(isEquals);
                 }
         }
 }

--- a/src/Humanizer.Tests/MetricNumeralTests.cs
+++ b/src/Humanizer.Tests/MetricNumeralTests.cs
@@ -38,7 +38,9 @@ namespace Humanizer.Tests
                 [InlineData(123d, "123")]
                 [InlineData(-123d, "-123")]
                 [InlineData(1230d, "1.23k")]
-                [InlineData(1000d, "1 k")]
+		[InlineData(1000d, "1 k")]
+		[InlineData(1000d, "1 kilo")]
+		[InlineData(1E-3, "1milli")]
                 public void FromMetric(double expected, string input)
                 {
                         Assert.Equal(expected, input.FromMetric());
@@ -51,7 +53,9 @@ namespace Humanizer.Tests
                 [InlineData("12yy")]
                 [InlineData("-8e")]
                 [InlineData("0.12c")]
-                [InlineData("0.02l")]
+		[InlineData("0.02l")]
+		[InlineData("0.12kilkilo")]
+		[InlineData("0.02alois")]
                 public void FromMetricOnInvalid(string input)
                 {
                         Assert.Throws<ArgumentException>(() => input.FromMetric());

--- a/src/Humanizer.Tests/MetricNumeralTests.cs
+++ b/src/Humanizer.Tests/MetricNumeralTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Humanizer.Tests
+{
+        public class MetricNumeralTests
+        {
+                [Theory]
+                [InlineData("0", 0d, false)]
+                [InlineData("123", 123d, false)]
+                [InlineData("-123", (-123d), false)]
+                [InlineData("1.23k", 1230d, false)]
+                [InlineData("1 k", 1000d, true)]
+                public void ToMetric(string expected, double input, bool isSplitedBySpace = false)
+                {
+                        Assert.Equal(expected, input.ToMetric(isSplitedBySpace));
+                }
+
+                [Theory]
+                [InlineData(0, "0")]
+                [InlineData(123d, "123")]
+                [InlineData(-123d, "-123")]
+                [InlineData(1230d, "1.23k")]
+                [InlineData(1000d, "1 k")]
+                public void FromMetric(double expected, string input)
+                {
+                        Assert.Equal(expected, input.FromMetric());
+                }
+
+                [Fact]
+                public void TestAllSymbols()
+                {
+                        var b = true;
+                        for (var i = -24; i < 27; i++)
+                        {
+                                var origin = Math.Pow(10, i);
+                                var to = origin.ToMetric();
+                                var from = to.FromMetric();
+
+                                var c = Equals(
+                                        origin.ToString("0.##E+0", CultureInfo.InvariantCulture),
+                                        from.ToString("0.##E+0", CultureInfo.InvariantCulture));
+                                if (!c)
+                                        Debugger.Break();
+
+                                b &= c;
+                        }
+                        Assert.True(b);
+                }
+        }
+}

--- a/src/Humanizer.Tests/MetricNumeralTests.cs
+++ b/src/Humanizer.Tests/MetricNumeralTests.cs
@@ -18,9 +18,9 @@ namespace Humanizer.Tests
                 [InlineData("1 kilo", 1000d, true, false)]
                 [InlineData("1milli", 1E-3, false, false)]
                 public void ToMetric(string expected, double input,
-                        bool isSplitedBySpace, bool useSymbol)
+                        bool hasSpace, bool useSymbol)
                 {
-                        Assert.Equal(expected, input.ToMetric(isSplitedBySpace, useSymbol));
+                        Assert.Equal(expected, input.ToMetric(hasSpace, useSymbol));
                 }
 
                 [Theory]

--- a/src/Humanizer.Tests/MetricNumeralTests.cs
+++ b/src/Humanizer.Tests/MetricNumeralTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using Xunit;
 using Xunit.Extensions;
 
@@ -21,6 +20,16 @@ namespace Humanizer.Tests
                 }
 
                 [Theory]
+                [InlineData(1E+27)]
+                [InlineData(1E-27)]
+                [InlineData(-1E+27)]
+                [InlineData(-1E-27)]
+                public void ToMetricOnInvalid(double input)
+                {
+                       Assert.Throws<ArgumentOutOfRangeException>(() => input.ToMetric());
+                }
+
+                [Theory]
                 [InlineData(0, "0")]
                 [InlineData(123d, "123")]
                 [InlineData(-123d, "-123")]
@@ -31,6 +40,25 @@ namespace Humanizer.Tests
                         Assert.Equal(expected, input.FromMetric());
                 }
 
+                [Theory]
+                [InlineData("")]
+                [InlineData(" ")]
+                [InlineData("\t")]
+                [InlineData("12yy")]
+                [InlineData("-8e")]
+                [InlineData("0.12c")]
+                [InlineData("0.02l")]
+                public void FromMetricOnInvalid(string input)
+                {
+                        Assert.Throws<ArgumentException>(() => input.FromMetric());
+                }
+
+                [Fact]
+                public void FromMetricOnNull()
+                {
+                        Assert.Throws<ArgumentNullException>(() =>
+                                MetricNumeralExtensions.FromMetric(null));
+                }
 
 
                 [Fact]

--- a/src/Humanizer.Tests/MetricNumeralTests.cs
+++ b/src/Humanizer.Tests/MetricNumeralTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Globalization;
+using System.Net.Configuration;
 using Xunit;
 using Xunit.Extensions;
 
@@ -9,14 +10,17 @@ namespace Humanizer.Tests
         public class MetricNumeralTests
         {
                 [Theory]
-                [InlineData("0", 0d, false)]
-                [InlineData("123", 123d, false)]
-                [InlineData("-123", (-123d), false)]
-                [InlineData("1.23k", 1230d, false)]
-                [InlineData("1 k", 1000d, true)]
-                public void ToMetric(string expected, double input, bool isSplitedBySpace = false)
+                [InlineData("0", 0d, false, true)]
+                [InlineData("123", 123d, false, true)]
+                [InlineData("-123", (-123d), false, true)]
+                [InlineData("1.23k", 1230d, false, true)]
+                [InlineData("1 k", 1000d, true, true)]
+                [InlineData("1 kilo", 1000d, true, false)]
+                [InlineData("1milli", 1E-3, false, false)]
+                public void ToMetric(string expected, double input,
+                        bool isSplitedBySpace, bool useSymbol)
                 {
-                        Assert.Equal(expected, input.ToMetric(isSplitedBySpace));
+                        Assert.Equal(expected, input.ToMetric(isSplitedBySpace, useSymbol));
                 }
 
                 [Theory]
@@ -26,7 +30,7 @@ namespace Humanizer.Tests
                 [InlineData(-1E-27)]
                 public void ToMetricOnInvalid(double input)
                 {
-                       Assert.Throws<ArgumentOutOfRangeException>(() => input.ToMetric());
+                        Assert.Throws<ArgumentOutOfRangeException>(() => input.ToMetric());
                 }
 
                 [Theory]

--- a/src/Humanizer/Humanizer.csproj
+++ b/src/Humanizer/Humanizer.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Localisation\Ordinalizers\UkrainianOrdinalizer.cs" />
     <Compile Include="Localisation\Tense.cs" />
     <Compile Include="Localisation\NumberToWords\SpanishNumberToWordsConverter.cs" />
+    <Compile Include="MetricNumeralExtensions.cs" />
     <Compile Include="Plurality.cs" />
     <Compile Include="RegexOptionsUtil.cs" />
     <Compile Include="TimeSpanHumanizeExtensions.cs" />

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -1,0 +1,147 @@
+﻿// Wrote by Alois de Gouvello https://github.com/aloisdg
+
+// The MIT License (MIT)
+
+// Copyright (c) 2015 Alois de Gouvello
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Humanizer
+{
+        /// <summary>
+        /// Contains extension methods for changing a number to Metric representation (ToMetric)
+        /// and from Metric representation back to the number (FromMetric)
+        /// </summary>
+        public static class MetricNumeralExtensions
+        {
+                /// <summary>
+                /// Symbols is a list of every symbols for the Metric system.
+                /// </summary>
+                private static readonly char[][] Symbols =
+                {
+                        new[] { 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y' },
+                        new[] { 'm', '\u03bc', 'n', 'p', 'f', 'a', 'z', 'y' }
+                };
+
+                /// <summary>
+                /// Converts a Metric representation into a number.
+                /// </summary>
+                /// <param name="input">Metric representation to convert to a number</param>
+                /// <example>
+                /// "1k".FromMetric() => 1000d
+                /// "123".FromMetric() => 123d
+                /// "100m".FromMetric() => 1E-1
+                /// </example>
+                /// <returns>A number after a conversion from a Metric representation.</returns>
+                public static double FromMetric(this string input)
+                {
+                        if (input == null) throw new ArgumentNullException("input");
+                        input = input.Trim();
+                        if (input.Length == 0 || input.IsInvalidMetricNumeral())
+                                throw new ArgumentException("Empty or invalid Metric string.", "input");
+                        input = input.Replace(" ", String.Empty);
+                        var last = input[input.Length - 1];
+                        if (!Char.IsLetter(last)) return Double.Parse(input);
+                        Func<char[], double> getExponent = symbols => (symbols.IndexOf(last) + 1) * 3;
+                        var number = Double.Parse(input.Remove(input.Length - 1));
+                        var exponent = Math.Pow(10, Symbols[0].Contains(last) ? getExponent(Symbols[0]) : -getExponent(Symbols[1]));
+                        return number * exponent;
+                }
+
+                /// <summary>
+                /// Converts a number into a valid and Human-readable Metric representation.
+                /// </summary>
+                /// <remarks>
+                /// Inspired by a snippet from Thom Smith.
+                /// <see cref="http://stackoverflow.com/questions/12181024/formatting-a-number-with-a-metric-prefix"/>
+                /// </remarks>
+                /// <param name="input">Number to convert to a Metric representation.</param>
+                /// <param name="isSplitedBySpace">True will split the number and the symbol with a whitespace.</param>
+                /// <example>
+                /// 1000d.ToMetric() => "1k"
+                /// 123d.ToMetric() => "123"
+                /// 1E-1.ToMetric() => "100m"
+                /// </example>
+                /// <returns>A valid Metric representation</returns>
+                public static string ToMetric(this double input, bool isSplitedBySpace = false)
+                {
+                        if (input.Equals(0)) return input.ToString();
+                        if (input.IsOutOfRange()) throw new ArgumentOutOfRangeException("input");
+                        var exponent = (int)Math.Floor(Math.Log10(Math.Abs(input)) / 3);
+                        if (exponent == 0) return input.ToString();
+                        return input * Math.Pow(1000, -exponent)
+                                + (isSplitedBySpace ? " " : String.Empty)
+                                + (Math.Sign(exponent) == 1 ? Symbols[0][exponent - 1] : Symbols[1][-exponent - 1]);
+                }
+
+                /// <summary>
+                /// Check if a Metric representation is out of the valid range.
+                /// </summary>
+                /// <param name="input">A Metric representation who might be out of the valid range.</param>
+                /// <returns>True if input is out of the valid range.</returns>
+                private static bool IsOutOfRange(this double input)
+                {
+                        const int limit = 27;
+                        var bigLimit = Math.Pow(10, limit);
+                        var smallLimit = Math.Pow(10, -limit);
+                        Func<double, double, bool> outside = (min, max) => !(max > input && input > min);
+                        return (Math.Sign(input) == 1 && outside(smallLimit, bigLimit))
+                               || (Math.Sign(input) == -1 && outside(-bigLimit, -smallLimit));
+                }
+
+                /// <summary>
+                /// Check if a string is not a valid Metric representation.
+                /// A valid representation is in the format "{0}{1}" or "{0} {1}"
+                /// where {0} is a number and {1} is an allowed symbol.
+                /// </summary>
+                /// <remarks>
+                /// ToDo: Performance: Use (string input, out number) to escape the double use of Parse()
+                /// </remarks>
+                /// <param name="input">A string who might contain a invalid Metric representation.</param>
+                /// <returns>True if input is not a valid Metric representation.</returns>
+                private static bool IsInvalidMetricNumeral(this string input)
+                {
+                        double number;
+                        var index = input.Length - 1;
+                        var last = input[index];
+                        var isSymbol = Symbols[0].Contains(last) || Symbols[1].Contains(last);
+                        return !Double.TryParse(isSymbol ? input.Remove(index) : input, out number);
+                }
+
+                /// <summary>
+                /// Reports the zero-based index of the first occurrence of the specified Unicode
+                /// character in this string.
+                /// </summary>
+                /// <param name="chars">The string containing the value.</param>
+                /// <param name="value">A Unicode character to seek.</param>
+                /// <returns>
+                /// The zero-based index position of value if that character is found, or -1 if it is not.
+                /// </returns>
+                private static int IndexOf(this ICollection<char> chars, char value)
+                {
+                        for (var i = 0; i < chars.Count; i++)
+                                if (chars.ElementAt(i).Equals(value))
+                                        return i;
+                        return -1;
+                }
+        }
+}

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -42,27 +42,31 @@ namespace Humanizer
                         new[] { 'm', '\u03bc', 'n', 'p', 'f', 'a', 'z', 'y' }
                 };
 
-//                yotta Y 1000 8 10 24 1 000 000 000 000 000 000 000000 septillion quadrillion 1991
-//zetta Z 1000 7 10 21 1 000 000 000 000 000 000 000 sextillion thousand trillion 1991
-//exa E 1000 6 10 18 1 000 000 000 000 000 000 quintillion trillion 1975
-//peta P 1000 5 10 15 1 000 000 000 000 000 quadrillion thousand billion 1975
-//tera T 1000 4 10 12 1 000 000000 000 trillion billion 1960
-//giga G 1000 3 10 9 1 000 000000 billion thousand million 1960
-//mega M 1000 2 10 6 1 000 000 million 1960 (1873)
-//kilo k 1000 1 10 3 1 000 thousand 1960 (1795)
-//hecto h 1000 2/3 10 2 100 hundred 1960 (1795)
-//deca da 1000 1/3 10 1 10 ten 1960 (1795)
-//1000 0 10 0 1 one –
-//deci d 1000 −1/3 10 −1 0.1 tenth 1960 (1795)
-//centi c 1000 −2/3 10 −2 0.01 hundredth 1960 (1795)
-//milli m 1000 −1 10 −3 0.001 thousandth 1960 (1795)
-//micro μ 1000 −2 10 −6 0.000 001 millionth 1960 (1873)
-//nano n 1000 −3 10 −9 0.000 000 001 billionth thousand millionth 1960
-//pico p 1000 −4 10 −12 0.000 000 000001 trillionth billionth 1960
-//femto f 1000 −5 10 −15 0.000 000 000000 001 quadrillionth thousand billionth 1964
-//atto a 1000 −6 10 −18 0.000 000 000000 000 001 quintillionth trillionth 1964
-//zepto z 1000 −7 10 −21 0.000 000 000000 000 000 001 sextillionth thousand trillionth 1991
-//yocto y
+                //private static readonly Dictionary<char, string> Names = new Dictionary<char, string>()
+                //{
+                //         {"Y", "yotta" },
+                //         {"Z", "zetta" },
+                //         {"E", "exa" },
+                //         {"P", "peta" },
+                //         {"T", "tera" },
+                //         {"G", "giga" },
+                //         {"M", "mega" },
+                //         {"k", "kilo" },
+                //         //{"h", "hecto"},
+                //         //{"e", "deca" }, // "da" is read as 'e'
+                //         //{"d", "deci" },
+                //         //{"c", "centi"},
+                //         {"m", "milli" },
+                //         {"μ", "micro" },
+                //         {"n", "nano" },
+                //         {"p", "pico" },
+                //         {"f", "femto" },
+                //         {"a", "atto" },
+                //         {"z", "zepto" },
+                //         {"y", "yocto" }
+                //};
+
+
 
                 /// <summary>
                 /// Converts a Metric representation into a number.

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -42,6 +42,28 @@ namespace Humanizer
                         new[] { 'm', '\u03bc', 'n', 'p', 'f', 'a', 'z', 'y' }
                 };
 
+//                yotta Y 1000 8 10 24 1 000 000 000 000 000 000 000000 septillion quadrillion 1991
+//zetta Z 1000 7 10 21 1 000 000 000 000 000 000 000 sextillion thousand trillion 1991
+//exa E 1000 6 10 18 1 000 000 000 000 000 000 quintillion trillion 1975
+//peta P 1000 5 10 15 1 000 000 000 000 000 quadrillion thousand billion 1975
+//tera T 1000 4 10 12 1 000 000000 000 trillion billion 1960
+//giga G 1000 3 10 9 1 000 000000 billion thousand million 1960
+//mega M 1000 2 10 6 1 000 000 million 1960 (1873)
+//kilo k 1000 1 10 3 1 000 thousand 1960 (1795)
+//hecto h 1000 2/3 10 2 100 hundred 1960 (1795)
+//deca da 1000 1/3 10 1 10 ten 1960 (1795)
+//1000 0 10 0 1 one –
+//deci d 1000 −1/3 10 −1 0.1 tenth 1960 (1795)
+//centi c 1000 −2/3 10 −2 0.01 hundredth 1960 (1795)
+//milli m 1000 −1 10 −3 0.001 thousandth 1960 (1795)
+//micro μ 1000 −2 10 −6 0.000 001 millionth 1960 (1873)
+//nano n 1000 −3 10 −9 0.000 000 001 billionth thousand millionth 1960
+//pico p 1000 −4 10 −12 0.000 000 000001 trillionth billionth 1960
+//femto f 1000 −5 10 −15 0.000 000 000000 001 quadrillionth thousand billionth 1964
+//atto a 1000 −6 10 −18 0.000 000 000000 000 001 quintillionth trillionth 1964
+//zepto z 1000 −7 10 −21 0.000 000 000000 000 000 001 sextillionth thousand trillionth 1991
+//yocto y
+
                 /// <summary>
                 /// Converts a Metric representation into a number.
                 /// </summary>

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -42,33 +42,29 @@ namespace Humanizer
                         new[] { 'm', '\u03bc', 'n', 'p', 'f', 'a', 'z', 'y' }
                 };
 
-                //private static readonly Dictionary<char, string> Names = new Dictionary<char, string>()
-                //{
-                //         {"Y", "yotta" },
-                //         {"Z", "zetta" },
-                //         {"E", "exa" },
-                //         {"P", "peta" },
-                //         {"T", "tera" },
-                //         {"G", "giga" },
-                //         {"M", "mega" },
-                //         {"k", "kilo" },
-                //         //{"h", "hecto"},
-                //         //{"e", "deca" }, // "da" is read as 'e'
-                //         //{"d", "deci" },
-                //         //{"c", "centi"},
-                //         {"m", "milli" },
-                //         {"μ", "micro" },
-                //         {"n", "nano" },
-                //         {"p", "pico" },
-                //         {"f", "femto" },
-                //         {"a", "atto" },
-                //         {"z", "zepto" },
-                //         {"y", "yocto" }
-                //};
+                /// <summary>
+                /// Names link a Metric symbol (as key) to its name (as value).
+                /// </summary>
+                /// <remarks>
+                /// We dont support :
+                /// {'h', "hecto"},
+                /// {'da', "deca" }, // !string
+                /// {'d', "deci" },
+                /// {'c', "centi"},
+                /// </remarks>
+                private static readonly Dictionary<char, string> Names = new Dictionary<char, string>()
+                {
+                         {'Y', "yotta" }, {'Z', "zetta" }, {'E', "exa" }, {'P', "peta" }, {'T', "tera" }, {'G', "giga" }, {'M', "mega" }, {'k', "kilo" },
+                         {'m', "milli" }, {'μ', "micro" }, {'n', "nano" }, {'p', "pico" }, {'f', "femto" }, {'a', "atto" }, {'z', "zepto" }, {'y', "yocto" }
+                };
 
                 /// <summary>
                 /// Converts a Metric representation into a number.
                 /// </summary>
+                /// <remarks>
+                /// We don't support input in the format {number}{name} nor {number} {name}.
+                /// We only provide a solution for {number}{symbol} and {number} {symbol}.
+                /// </remarks>
                 /// <param name="input">Metric representation to convert to a number</param>
                 /// <example>
                 /// "1k".FromMetric() => 1000d
@@ -100,13 +96,14 @@ namespace Humanizer
                 /// </remarks>
                 /// <param name="input">Number to convert to a Metric representation.</param>
                 /// <param name="isSplitedBySpace">True will split the number and the symbol with a whitespace.</param>
+                /// <param name="useSymbol">True will use symbol instead of name</param>
                 /// <example>
                 /// 1000d.ToMetric() => "1k"
                 /// 123d.ToMetric() => "123"
                 /// 1E-1.ToMetric() => "100m"
                 /// </example>
                 /// <returns>A valid Metric representation</returns>
-                public static string ToMetric(this double input, bool isSplitedBySpace = false)
+                public static string ToMetric(this double input, bool isSplitedBySpace = false, bool useSymbol = true)
                 {
                         if (input.Equals(0)) return input.ToString();
                         if (input.IsOutOfRange()) throw new ArgumentOutOfRangeException("input");
@@ -114,7 +111,7 @@ namespace Humanizer
                         if (exponent == 0) return input.ToString();
                         return input * Math.Pow(1000, -exponent)
                                 + (isSplitedBySpace ? " " : String.Empty)
-                                + (Math.Sign(exponent) == 1 ? Symbols[0][exponent - 1] : Symbols[1][-exponent - 1]);
+                                + GetUnit((Math.Sign(exponent) == 1 ? Symbols[0][exponent - 1] : Symbols[1][-exponent - 1]), useSymbol);
                 }
 
                 /// <summary>
@@ -126,15 +123,27 @@ namespace Humanizer
                 /// </remarks>
                 /// <param name="input">Number to convert to a Metric representation.</param>
                 /// <param name="isSplitedBySpace">True will split the number and the symbol with a whitespace.</param>
+                /// <param name="useSymbol">True will use symbol instead of name</param>
                 /// <example>
                 /// 1000.ToMetric() => "1k"
                 /// 123.ToMetric() => "123"
                 /// 1E-1.ToMetric() => "100m"
                 /// </example>
                 /// <returns>A valid Metric representation</returns>
-                public static string ToMetric(this int input, bool isSplitedBySpace = false)
+                public static string ToMetric(this int input, bool isSplitedBySpace = false, bool useSymbol = true)
                 {
-                        return Convert.ToDouble(input).ToMetric(isSplitedBySpace);
+                        return Convert.ToDouble(input).ToMetric(isSplitedBySpace, useSymbol);
+                }
+
+                /// <summary>
+                /// Get the unit from a symbol of from the symbol's name.
+                /// </summary>
+                /// <param name="symbol">The symbol linked to the unit</param>
+                /// <param name="useSymbol">True will use symbol instead of name</param>
+                /// <returns>A symbol or a symbol's name</returns>
+                private static string GetUnit(char symbol, bool useSymbol)
+                {
+                        return useSymbol ? symbol.ToString() : Names[symbol];
                 }
 
                 /// <summary>

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -66,8 +66,6 @@ namespace Humanizer
                 //         {"y", "yocto" }
                 //};
 
-
-
                 /// <summary>
                 /// Converts a Metric representation into a number.
                 /// </summary>
@@ -117,6 +115,26 @@ namespace Humanizer
                         return input * Math.Pow(1000, -exponent)
                                 + (isSplitedBySpace ? " " : String.Empty)
                                 + (Math.Sign(exponent) == 1 ? Symbols[0][exponent - 1] : Symbols[1][-exponent - 1]);
+                }
+
+                /// <summary>
+                /// Converts a number into a valid and Human-readable Metric representation.
+                /// </summary>
+                /// <remarks>
+                /// Inspired by a snippet from Thom Smith.
+                /// <see cref="http://stackoverflow.com/questions/12181024/formatting-a-number-with-a-metric-prefix"/>
+                /// </remarks>
+                /// <param name="input">Number to convert to a Metric representation.</param>
+                /// <param name="isSplitedBySpace">True will split the number and the symbol with a whitespace.</param>
+                /// <example>
+                /// 1000.ToMetric() => "1k"
+                /// 123.ToMetric() => "123"
+                /// 1E-1.ToMetric() => "100m"
+                /// </example>
+                /// <returns>A valid Metric representation</returns>
+                public static string ToMetric(this int input, bool isSplitedBySpace = false)
+                {
+                        return Convert.ToDouble(input).ToMetric(isSplitedBySpace);
                 }
 
                 /// <summary>

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -115,9 +115,11 @@ namespace Humanizer
                         if (input.IsOutOfRange()) throw new ArgumentOutOfRangeException("input");
                         var exponent = (int)Math.Floor(Math.Log10(Math.Abs(input)) / 3);
                         if (exponent == 0) return input.ToString();
-                        return input * Math.Pow(1000, -exponent)
+	                var number = input*Math.Pow(1000, -exponent);
+	                var symbol = Math.Sign(exponent) == 1 ? Symbols[0][exponent - 1] : Symbols[1][-exponent - 1];
+                        return number
                                 + (isSplitedBySpace ? " " : String.Empty)
-                                + GetUnit((Math.Sign(exponent) == 1 ? Symbols[0][exponent - 1] : Symbols[1][-exponent - 1]), useSymbol);
+                                + GetUnit(symbol, useSymbol);
                 }
 
                 /// <summary>

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -27,182 +27,187 @@ using System.Linq;
 
 namespace Humanizer
 {
-        /// <summary>
-        /// Contains extension methods for changing a number to Metric representation (ToMetric)
-        /// and from Metric representation back to the number (FromMetric)
-        /// </summary>
-        public static class MetricNumeralExtensions
-        {
-                /// <summary>
-                /// Symbols is a list of every symbols for the Metric system.
-                /// </summary>
-                private static readonly char[][] Symbols =
+	/// <summary>
+	/// Contains extension methods for changing a number to Metric representation (ToMetric)
+	/// and from Metric representation back to the number (FromMetric)
+	/// </summary>
+	public static class MetricNumeralExtensions
+	{
+		/// <summary>
+		/// Symbols is a list of every symbols for the Metric system.
+		/// </summary>
+		private static readonly char[][] Symbols =
                 {
                         new[] { 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y' },
                         new[] { 'm', '\u03bc', 'n', 'p', 'f', 'a', 'z', 'y' }
                 };
 
-                /// <summary>
-                /// Names link a Metric symbol (as key) to its name (as value).
-                /// </summary>
-                /// <remarks>
-                /// We dont support :
-                /// {'h', "hecto"},
-                /// {'da', "deca" }, // !string
-                /// {'d', "deci" },
-                /// {'c', "centi"},
-                /// </remarks>
-                private static readonly Dictionary<char, string> Names = new Dictionary<char, string>()
+		/// <summary>
+		/// Names link a Metric symbol (as key) to its name (as value).
+		/// </summary>
+		/// <remarks>
+		/// We dont support :
+		/// {'h', "hecto"},
+		/// {'da', "deca" }, // !string
+		/// {'d', "deci" },
+		/// {'c', "centi"},
+		/// </remarks>
+		private static readonly Dictionary<char, string> Names = new Dictionary<char, string>()
                 {
                          {'Y', "yotta" }, {'Z', "zetta" }, {'E', "exa" }, {'P', "peta" }, {'T', "tera" }, {'G', "giga" }, {'M', "mega" }, {'k', "kilo" },
                          {'m', "milli" }, {'μ', "micro" }, {'n', "nano" }, {'p', "pico" }, {'f', "femto" }, {'a', "atto" }, {'z', "zepto" }, {'y', "yocto" }
                 };
 
-                /// <summary>
-                /// Converts a Metric representation into a number.
-                /// </summary>
-                /// <remarks>
-                /// We don't support input in the format {number}{name} nor {number} {name}.
-                /// We only provide a solution for {number}{symbol} and {number} {symbol}.
-                /// </remarks>
-                /// <param name="input">Metric representation to convert to a number</param>
-                /// <example>
-                /// "1k".FromMetric() => 1000d
-                /// "123".FromMetric() => 123d
-                /// "100m".FromMetric() => 1E-1
-                /// </example>
-                /// <returns>A number after a conversion from a Metric representation.</returns>
-                public static double FromMetric(this string input)
-                {
-                        if (input == null) throw new ArgumentNullException("input");
-                        input = input.Trim();
-                        input = ReplaceNameBySymbol(input);
-                        if (input.Length == 0 || input.IsInvalidMetricNumeral())
-                                throw new ArgumentException("Empty or invalid Metric string.", "input");
-                        input = input.Replace(" ", String.Empty);
-                        var last = input[input.Length - 1];
-                        if (!Char.IsLetter(last)) return Double.Parse(input);
-                        Func<char[], double> getExponent = symbols => (symbols.IndexOf(last) + 1) * 3;
-                        var number = Double.Parse(input.Remove(input.Length - 1));
-                        var exponent = Math.Pow(10, Symbols[0].Contains(last) ? getExponent(Symbols[0]) : -getExponent(Symbols[1]));
-                        return number * exponent;
-                }
+		/// <summary>
+		/// Converts a Metric representation into a number.
+		/// </summary>
+		/// <remarks>
+		/// We don't support input in the format {number}{name} nor {number} {name}.
+		/// We only provide a solution for {number}{symbol} and {number} {symbol}.
+		/// </remarks>
+		/// <param name="input">Metric representation to convert to a number</param>
+		/// <example>
+		/// "1k".FromMetric() => 1000d
+		/// "123".FromMetric() => 123d
+		/// "100m".FromMetric() => 1E-1
+		/// </example>
+		/// <returns>A number after a conversion from a Metric representation.</returns>
+		public static double FromMetric(this string input)
+		{
+			if (input == null) throw new ArgumentNullException("input");
+			input = input.Trim();
+			input = ReplaceNameBySymbol(input);
+			if (input.Length == 0 || input.IsInvalidMetricNumeral())
+				throw new ArgumentException("Empty or invalid Metric string.", "input");
+			input = input.Replace(" ", String.Empty);
+			var last = input[input.Length - 1];
+			if (!Char.IsLetter(last)) return Double.Parse(input);
+			Func<char[], double> getExponent = symbols => (symbols.IndexOf(last) + 1) * 3;
+			var number = Double.Parse(input.Remove(input.Length - 1));
+			var exponent = Math.Pow(10, Symbols[0].Contains(last) ? getExponent(Symbols[0]) : -getExponent(Symbols[1]));
+			return number * exponent;
+		}
 
-                private static string ReplaceNameBySymbol(string input)
-                {
-                        return Names.Aggregate(input, (current, name) => current.Replace(name.Value, name.Key.ToString()));
-                }
+		/// <summary>
+		/// Replace every symbol's name by its symbol representation.
+		/// </summary>
+		/// <param name="input">Metric representation with a name or a symbol</param>
+		/// <returns>A metric representation with a symbol</returns>
+		private static string ReplaceNameBySymbol(string input)
+		{
+			return Names.Aggregate(input, (current, name) => current.Replace(name.Value, name.Key.ToString()));
+		}
 
-                /// <summary>
-                /// Converts a number into a valid and Human-readable Metric representation.
-                /// </summary>
-                /// <remarks>
-                /// Inspired by a snippet from Thom Smith.
-                /// <see cref="http://stackoverflow.com/questions/12181024/formatting-a-number-with-a-metric-prefix"/>
-                /// </remarks>
-                /// <param name="input">Number to convert to a Metric representation.</param>
-                /// <param name="isSplitedBySpace">True will split the number and the symbol with a whitespace.</param>
-                /// <param name="useSymbol">True will use symbol instead of name</param>
-                /// <example>
-                /// 1000d.ToMetric() => "1k"
-                /// 123d.ToMetric() => "123"
-                /// 1E-1.ToMetric() => "100m"
-                /// </example>
-                /// <returns>A valid Metric representation</returns>
-                public static string ToMetric(this double input, bool isSplitedBySpace = false, bool useSymbol = true)
-                {
-                        if (input.Equals(0)) return input.ToString();
-                        if (input.IsOutOfRange()) throw new ArgumentOutOfRangeException("input");
-                        var exponent = (int)Math.Floor(Math.Log10(Math.Abs(input)) / 3);
-                        if (exponent == 0) return input.ToString();
-	                var number = input*Math.Pow(1000, -exponent);
-	                var symbol = Math.Sign(exponent) == 1 ? Symbols[0][exponent - 1] : Symbols[1][-exponent - 1];
-                        return number
-                                + (isSplitedBySpace ? " " : String.Empty)
-                                + GetUnit(symbol, useSymbol);
-                }
+		/// <summary>
+		/// Converts a number into a valid and Human-readable Metric representation.
+		/// </summary>
+		/// <remarks>
+		/// Inspired by a snippet from Thom Smith.
+		/// <see cref="http://stackoverflow.com/questions/12181024/formatting-a-number-with-a-metric-prefix"/>
+		/// </remarks>
+		/// <param name="input">Number to convert to a Metric representation.</param>
+		/// <param name="isSplitedBySpace">True will split the number and the symbol with a whitespace.</param>
+		/// <param name="useSymbol">True will use symbol instead of name</param>
+		/// <example>
+		/// 1000d.ToMetric() => "1k"
+		/// 123d.ToMetric() => "123"
+		/// 1E-1.ToMetric() => "100m"
+		/// </example>
+		/// <returns>A valid Metric representation</returns>
+		public static string ToMetric(this double input, bool isSplitedBySpace = false, bool useSymbol = true)
+		{
+			if (input.Equals(0)) return input.ToString();
+			if (input.IsOutOfRange()) throw new ArgumentOutOfRangeException("input");
+			var exponent = (int)Math.Floor(Math.Log10(Math.Abs(input)) / 3);
+			if (exponent == 0) return input.ToString();
+			var number = input * Math.Pow(1000, -exponent);
+			var symbol = Math.Sign(exponent) == 1 ? Symbols[0][exponent - 1] : Symbols[1][-exponent - 1];
+			return number
+				+ (isSplitedBySpace ? " " : String.Empty)
+				+ GetUnit(symbol, useSymbol);
+		}
 
-                /// <summary>
-                /// Converts a number into a valid and Human-readable Metric representation.
-                /// </summary>
-                /// <remarks>
-                /// Inspired by a snippet from Thom Smith.
-                /// <see cref="http://stackoverflow.com/questions/12181024/formatting-a-number-with-a-metric-prefix"/>
-                /// </remarks>
-                /// <param name="input">Number to convert to a Metric representation.</param>
-                /// <param name="isSplitedBySpace">True will split the number and the symbol with a whitespace.</param>
-                /// <param name="useSymbol">True will use symbol instead of name</param>
-                /// <example>
-                /// 1000.ToMetric() => "1k"
-                /// 123.ToMetric() => "123"
-                /// 1E-1.ToMetric() => "100m"
-                /// </example>
-                /// <returns>A valid Metric representation</returns>
-                public static string ToMetric(this int input, bool isSplitedBySpace = false, bool useSymbol = true)
-                {
-                        return Convert.ToDouble(input).ToMetric(isSplitedBySpace, useSymbol);
-                }
+		/// <summary>
+		/// Converts a number into a valid and Human-readable Metric representation.
+		/// </summary>
+		/// <remarks>
+		/// Inspired by a snippet from Thom Smith.
+		/// <see cref="http://stackoverflow.com/questions/12181024/formatting-a-number-with-a-metric-prefix"/>
+		/// </remarks>
+		/// <param name="input">Number to convert to a Metric representation.</param>
+		/// <param name="isSplitedBySpace">True will split the number and the symbol with a whitespace.</param>
+		/// <param name="useSymbol">True will use symbol instead of name</param>
+		/// <example>
+		/// 1000.ToMetric() => "1k"
+		/// 123.ToMetric() => "123"
+		/// 1E-1.ToMetric() => "100m"
+		/// </example>
+		/// <returns>A valid Metric representation</returns>
+		public static string ToMetric(this int input, bool isSplitedBySpace = false, bool useSymbol = true)
+		{
+			return Convert.ToDouble(input).ToMetric(isSplitedBySpace, useSymbol);
+		}
 
-                /// <summary>
-                /// Get the unit from a symbol of from the symbol's name.
-                /// </summary>
-                /// <param name="symbol">The symbol linked to the unit</param>
-                /// <param name="useSymbol">True will use symbol instead of name</param>
-                /// <returns>A symbol or a symbol's name</returns>
-                private static string GetUnit(char symbol, bool useSymbol)
-                {
-                        return useSymbol ? symbol.ToString() : Names[symbol];
-                }
+		/// <summary>
+		/// Get the unit from a symbol of from the symbol's name.
+		/// </summary>
+		/// <param name="symbol">The symbol linked to the unit</param>
+		/// <param name="useSymbol">True will use symbol instead of name</param>
+		/// <returns>A symbol or a symbol's name</returns>
+		private static string GetUnit(char symbol, bool useSymbol)
+		{
+			return useSymbol ? symbol.ToString() : Names[symbol];
+		}
 
-                /// <summary>
-                /// Check if a Metric representation is out of the valid range.
-                /// </summary>
-                /// <param name="input">A Metric representation who might be out of the valid range.</param>
-                /// <returns>True if input is out of the valid range.</returns>
-                private static bool IsOutOfRange(this double input)
-                {
-                        const int limit = 27;
-                        var bigLimit = Math.Pow(10, limit);
-                        var smallLimit = Math.Pow(10, -limit);
-                        Func<double, double, bool> outside = (min, max) => !(max > input && input > min);
-                        return (Math.Sign(input) == 1 && outside(smallLimit, bigLimit))
-                               || (Math.Sign(input) == -1 && outside(-bigLimit, -smallLimit));
-                }
+		/// <summary>
+		/// Check if a Metric representation is out of the valid range.
+		/// </summary>
+		/// <param name="input">A Metric representation who might be out of the valid range.</param>
+		/// <returns>True if input is out of the valid range.</returns>
+		private static bool IsOutOfRange(this double input)
+		{
+			const int limit = 27;
+			var bigLimit = Math.Pow(10, limit);
+			var smallLimit = Math.Pow(10, -limit);
+			Func<double, double, bool> outside = (min, max) => !(max > input && input > min);
+			return (Math.Sign(input) == 1 && outside(smallLimit, bigLimit))
+			       || (Math.Sign(input) == -1 && outside(-bigLimit, -smallLimit));
+		}
 
-                /// <summary>
-                /// Check if a string is not a valid Metric representation.
-                /// A valid representation is in the format "{0}{1}" or "{0} {1}"
-                /// where {0} is a number and {1} is an allowed symbol.
-                /// </summary>
-                /// <remarks>
-                /// ToDo: Performance: Use (string input, out number) to escape the double use of Parse()
-                /// </remarks>
-                /// <param name="input">A string who might contain a invalid Metric representation.</param>
-                /// <returns>True if input is not a valid Metric representation.</returns>
-                private static bool IsInvalidMetricNumeral(this string input)
-                {
-                        double number;
-                        var index = input.Length - 1;
-                        var last = input[index];
-                        var isSymbol = Symbols[0].Contains(last) || Symbols[1].Contains(last);
-                        return !Double.TryParse(isSymbol ? input.Remove(index) : input, out number);
-                }
+		/// <summary>
+		/// Check if a string is not a valid Metric representation.
+		/// A valid representation is in the format "{0}{1}" or "{0} {1}"
+		/// where {0} is a number and {1} is an allowed symbol.
+		/// </summary>
+		/// <remarks>
+		/// ToDo: Performance: Use (string input, out number) to escape the double use of Parse()
+		/// </remarks>
+		/// <param name="input">A string who might contain a invalid Metric representation.</param>
+		/// <returns>True if input is not a valid Metric representation.</returns>
+		private static bool IsInvalidMetricNumeral(this string input)
+		{
+			double number;
+			var index = input.Length - 1;
+			var last = input[index];
+			var isSymbol = Symbols[0].Contains(last) || Symbols[1].Contains(last);
+			return !Double.TryParse(isSymbol ? input.Remove(index) : input, out number);
+		}
 
-                /// <summary>
-                /// Reports the zero-based index of the first occurrence of the specified Unicode
-                /// character in this string.
-                /// </summary>
-                /// <param name="chars">The string containing the value.</param>
-                /// <param name="value">A Unicode character to seek.</param>
-                /// <returns>
-                /// The zero-based index position of value if that character is found, or -1 if it is not.
-                /// </returns>
-                private static int IndexOf(this ICollection<char> chars, char value)
-                {
-                        for (var i = 0; i < chars.Count; i++)
-                                if (chars.ElementAt(i).Equals(value))
-                                        return i;
-                        return -1;
-                }
-        }
+		/// <summary>
+		/// Reports the zero-based index of the first occurrence of the specified Unicode
+		/// character in this string.
+		/// </summary>
+		/// <param name="chars">The string containing the value.</param>
+		/// <param name="value">A Unicode character to seek.</param>
+		/// <returns>
+		/// The zero-based index position of value if that character is found, or -1 if it is not.
+		/// </returns>
+		private static int IndexOf(this ICollection<char> chars, char value)
+		{
+			for (var i = 0; i < chars.Count; i++)
+				if (chars.ElementAt(i).Equals(value))
+					return i;
+			return -1;
+		}
+	}
 }

--- a/src/Humanizer/MetricNumeralExtensions.cs
+++ b/src/Humanizer/MetricNumeralExtensions.cs
@@ -76,6 +76,7 @@ namespace Humanizer
                 {
                         if (input == null) throw new ArgumentNullException("input");
                         input = input.Trim();
+                        input = ReplaceNameBySymbol(input);
                         if (input.Length == 0 || input.IsInvalidMetricNumeral())
                                 throw new ArgumentException("Empty or invalid Metric string.", "input");
                         input = input.Replace(" ", String.Empty);
@@ -85,6 +86,11 @@ namespace Humanizer
                         var number = Double.Parse(input.Remove(input.Length - 1));
                         var exponent = Math.Pow(10, Symbols[0].Contains(last) ? getExponent(Symbols[0]) : -getExponent(Symbols[1]));
                         return number * exponent;
+                }
+
+                private static string ReplaceNameBySymbol(string input)
+                {
+                        return Names.Aggregate(input, (current, name) => current.Replace(name.Value, name.Key.ToString()));
                 }
 
                 /// <summary>


### PR DESCRIPTION
Hello,

I created the PR because this is a full working draft. I would be glad to get any kind of reviews.
This is my first time with xUnit (coming from NUnit and MsTest).  Any help is welcome!

Features:

- [x] Convert from metric numeral expression (`double` only)
- [x] Convert to metric numeral expression (`double` only)
- [x] Add `int` support
- [x] Support all symbols (decimal include)
- [x] Support the name of each symbols (see [List of SI prefixes](https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes)) (partial => export is supported)
- [x] Support the name of each symbols (see [List of SI prefixes](https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes)) (partial => import is supported)
- [x] Handle space between number and symbol
- [ ] Add `ByteSize`'s similar syntax
- [ ] Add the choice of precision
- [ ] Add the support of _small_ symbol / name (this include a switch from char to string in symbols because of deca "da"). Full list : { hecto, h, 1E+2 }, { deca, da, 1E+1 }, { deci, d, 1E-1 }, { centi, c, 1E-2 }. This feature will be lock by default. A boolean in parameter will unlock it.

Also:
- [x] Up-to-date and complete XML documentation
- [x] Include unit tests
- [x] Include unit tests with exception coverage

cheers,